### PR TITLE
Add support to apply labels when upstream issue is closed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ python:
   - "3.7"
 install:
   - pip install tox
-  - pip install flake8
   - pip install coveralls
 jobs:
   include:
-    - stage: Linting Tests
-      script: flake8 sync2jira --max-line-length=140
     - stage: Unit Tests
       script: tox
       after_success:

--- a/docs/source/config-file.rst
+++ b/docs/source/config-file.rst
@@ -138,6 +138,8 @@ The config file is made up of multiple parts
         * Sync title
     * :code:`{'transition': True/'CUSTOM_TRANSITION'}`
         * Sync status (open/closed), Sync only status/Attempt to transition JIRA ticket to CUSTOM_TRANSITION on upstream closure
+    * :code:`{'on_close': {'apply_lables': ['label', ...]}}`
+        * When the upstream issue is closed, apply additional labels on the corresponding Jira ticket.
     * :code:`github_markdown`
         * If description syncing is turned on, this flag will convert Github markdown to plaintext. This uses the pypandoc module.
     * :code:`upstream_id`

--- a/sync2jira/confluence_client.py
+++ b/sync2jira/confluence_client.py
@@ -167,7 +167,7 @@ class ConfluenceClient:
             if html_text.replace(" ", "") != page_html.replace(" ", ""):
                 self.update_page(self.page_id, html_text)
         except:  # noqa E722
-            log.exception(f"Something went wrong updating confluence!")
+            log.exception("Something went wrong updating confluence!")
 
     def find_page(self):
         """ finds the page with confluence_page_title in confluence_space

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -718,7 +718,7 @@ def _update_jira_issue(existing, issue, client):
     log.info("Updating information for upstream issue: %s" % issue.title)
 
     # Get a list of what the user wants to update for the upstream issue
-    updates = issue.downstream.get('issue_updates', {})
+    updates = issue.downstream.get('issue_updates', [])
 
     # Update relevant data if needed
     # If the user has specified nothing

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1060,6 +1060,27 @@ def _update_assignee(client, existing, issue, updates):
                     confluence_client.update_stat_page(confluence_data)
 
 
+def _update_jira_labels(issue, labels):
+    """Update a Jira issue with 'labels'
+
+    Do this only if the current labels would change.
+
+    :param jira.resource.Issue issue: Jira issue to be updated
+    :param list<strings> labels: Lables to be applied on the issue
+    :returns: None
+    """
+    _labels = sorted(labels)
+    if _labels == sorted(issue.fields.labels):
+        return
+
+    data = {'labels': _labels}
+    issue.update(data)
+    log.info('Updated %s tag(s)' % len(_labels))
+    if confluence_client.update_stat:
+        confluence_data = {'Tags': len(_labels)}
+        confluence_client.update_stat_page(confluence_data)
+
+
 def _update_tags(updates, existing, issue):
     """
     Helper function to sync tags between upstream issue and downstream JIRA issue.
@@ -1086,13 +1107,7 @@ def _update_tags(updates, existing, issue):
     updated_labels = verify_tags(updated_labels)
 
     # Now we can update the JIRA if labels are different
-    if sorted(updated_labels) != sorted(existing.fields.labels):
-        data = {'labels': updated_labels}
-        existing.update(data)
-        log.info('Updated %s tag(s)' % len(updated_labels))
-        if confluence_client.update_stat:
-            confluence_data = {'Tags': len(updated_labels)}
-            confluence_client.update_stat_page(confluence_data)
+    _update_jira_labels(existing, updated_labels)
 
 
 def _update_description(existing, issue):

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -56,7 +56,8 @@ class TestDownstreamIssue(unittest.TestCase):
                 {'tags': {'overwrite': False}},
                 {'fixVersion': {'overwrite': False}},
                 {'assignee': {'overwrite': True}}, 'description', 'title',
-                {'transition': 'CUSTOM TRANSITION'}
+                {'transition': 'CUSTOM TRANSITION'},
+                {'on_close': {"apply_labels": ["closed-upstream"]}}
             ],
             'owner': 'mock_owner'
         }
@@ -79,6 +80,7 @@ class TestDownstreamIssue(unittest.TestCase):
                 {'fixVersion': {'overwrite': False}},
                 {'assignee': {'overwrite': True}}, 'description', 'title',
                 {'transition': 'CUSTOM TRANSITION'},
+                {'on_close': {"apply_labels": ["closed-upstream"]}}
             ]
 
         # Mock Jira transition
@@ -674,9 +676,11 @@ class TestDownstreamIssue(unittest.TestCase):
     @mock.patch(PATH + '_update_fixVersion')
     @mock.patch(PATH + '_update_transition')
     @mock.patch(PATH + '_update_assignee')
+    @mock.patch(PATH + '_update_on_close')
     @mock.patch('jira.client.JIRA')
     def test_update_jira_issue(self,
                                mock_client,
+                               mock_update_on_close,
                                mock_update_assignee,
                                mock_update_transition,
                                mock_update_fixVersion,
@@ -724,6 +728,7 @@ class TestDownstreamIssue(unittest.TestCase):
             self.mock_downstream,
             self.mock_issue
         )
+        mock_update_on_close.assert_called_once()
 
     @mock.patch(PATH + 'confluence_client')
     @mock.patch('jira.client.JIRA')
@@ -1705,3 +1710,69 @@ class TestDownstreamIssue(unittest.TestCase):
         self.mock_downstream.update.assert_called_with(
             {'description':
                  f"\nUpstream URL: {self.mock_issue.url}\n"})
+
+    @mock.patch(PATH + 'confluence_client')
+    def test_update_on_close_update(self,
+                             mock_confluence_client):
+        """
+        This function tests '_update_on_close' where there is an
+        "apply_labels" configuration, and labels need to be updated.
+        """
+        # Set up return values
+        mock_confluence_client.update_stat = True
+        self.mock_downstream.fields.description = ""
+        self.mock_issue.status = 'Closed'
+        updates = [{"on_close": {"apply_labels": ["closed-upstream"]}}]
+
+        # Call the function
+        d._update_on_close(self.mock_downstream, self.mock_issue, updates)
+
+        # Assert everything was called correctly
+        self.mock_downstream.update.assert_called_with(
+            {'labels':
+                 ["closed-upstream", "tag3", "tag4"]})
+
+    def test_update_on_close_no_change(self):
+        """
+        This function tests '_update_on_close' where there is an
+        "apply_labels" configuration but there is no update required.
+        """
+        # Set up return values
+        self.mock_issue.status = 'Closed'
+        updates = [{"on_close": {"apply_labels": ["tag4"]}}]
+
+        # Call the function
+        d._update_on_close(self.mock_downstream, self.mock_issue, updates)
+
+        # Assert everything was called correctly
+        self.mock_downstream.update.assert_not_called()
+
+    def test_update_on_close_no_action(self):
+        """
+        This function tests '_update_on_close' where there is no
+        "apply_labels" configuration.
+        """
+        # Set up return values
+        self.mock_issue.status = 'Closed'
+        updates = [{"on_close": {"some_other_action": None}}]
+
+        # Call the function
+        d._update_on_close(self.mock_downstream, self.mock_issue, updates)
+
+        # Assert everything was called correctly
+        self.mock_downstream.update.assert_not_called()
+
+    def test_update_on_close_no_config(self):
+        """
+        This function tests '_update_on_close' where there is no
+        configuration for close events.
+        """
+        # Set up return values
+        self.mock_issue.status = 'Closed'
+        updates = ["description"]
+
+        # Call the function
+        d._update_on_close(self.mock_downstream, self.mock_issue, updates)
+
+        # Assert everything was called correctly
+        self.mock_downstream.update.assert_not_called()

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1009,7 +1009,7 @@ class TestDownstreamIssue(unittest.TestCase):
         """
         # Set up return values
         mock_label_matching.return_value = 'mock_updated_labels'
-        mock_verify_tags.return_value = 'mock_verified_tags'
+        mock_verify_tags.return_value = ['mock_verified_tags']
         mock_confluence_client.update_stat = True
 
         # Call the function
@@ -1025,8 +1025,8 @@ class TestDownstreamIssue(unittest.TestCase):
             self.mock_downstream.fields.labels
         )
         mock_verify_tags.assert_called_with('mock_updated_labels')
-        self.mock_downstream.update.assert_called_with({'labels': 'mock_verified_tags'})
-        mock_confluence_client.update_stat_page.assert_called_with({'Tags': 18})
+        self.mock_downstream.update.assert_called_with({'labels': ['mock_verified_tags']})
+        mock_confluence_client.update_stat_page.assert_called_with({'Tags': 1})
 
     @mock.patch(PATH + 'verify_tags')
     @mock.patch(PATH + '_label_matching')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py37,lint
 
 [testenv]
 passenv = TRAVIS TRAVIS_*
@@ -21,3 +21,11 @@ sitepackages = False
 commands =
     coverage run -m pytest {posargs} --ignore=tests/integration_tests
 # Add the following line locally to get an HTML report --cov-report html:htmlcov-py37
+
+[testenv:lint]
+skip_install = true
+basepython = python3.7
+deps =
+    flake8
+commands =
+    flake8 sync2jira --max-line-length=140


### PR DESCRIPTION
Make it possible to configure a list of labels to be applied on Jira
cards, when the corresponding upstream issue is closed.

Example:

```python
{
    'issue_updates': [
        {'on_close': {'apply_labels': ['closed-upstream']}
    ]
}
```

This can come handy, when one doesn't want to automatically close
downstream issues when upstream issues are closed, but still want's to
have an easy way to filter for such issues in Jira.
