### PR TITLE
Add issue links to pr

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -434,13 +434,13 @@ def _get_existing_jira_issue_legacy(client, issue, config):
         return None
 
 
-def _attach_link(client, downstream, remote_link):
+def attach_link(client, downstream, remote_link):
     """
     Attaches the upstream link to the JIRA ticket.
 
     :param jira.client.JIRA client: JIRA client
     :param jira.resources.Issue downstream: Response from creating the JIRA ticket
-    :param str remote_link: Remote link
+    :param dict remote_link: Remote link dict with {'url': ...  , 'title': ... }
     :return: downstream: Response from creating the JIRA ticket
     :rtype: jira.resources.Issue
     """
@@ -477,7 +477,7 @@ def _upgrade_jira_issue(client, downstream, issue, config):
 
     # Do it!
     remote_link = dict(url=issue.url, title=remote_link_title)
-    _attach_link(client, downstream, remote_link)
+    attach_link(client, downstream, remote_link)
 
 
 def assign_user(client, issue, downstream, remove_all=False):
@@ -669,7 +669,7 @@ def _create_jira_issue(client, issue, config):
         confluence_data['Misc. Fields'] = 1
 
     remote_link = dict(url=issue.url, title=remote_link_title)
-    _attach_link(client, downstream, remote_link)
+    attach_link(client, downstream, remote_link)
 
     default_status = issue.downstream.get('default_status', None)
     if default_status is not None:

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -63,10 +63,26 @@ def format_comment(pr, pr_suffix, client):
     return comment
 
 
+def issue_link_exists(client, existing, pr):
+    """
+    Checks if we've already linked this PR
+
+    :param jira.client.JIRA client: JIRA Client
+    :param jira.resources.Issue existing: Existing JIRA issue that was found
+    :param sync2jira.intermediary.PR pr: Upstream issue we're pulling data from
+    :returns: True/False if the issue exists/does not exists
+    """
+    # Query for our issue
+    for issue_link in client.remote_links(existing):
+        if issue_link.object.url == pr.url:
+            # Issue has already been linked
+            return True
+    return False
+
+
 def comment_exists(client, existing, new_comment):
     """
     Checks if new_comment exists in existing
-
     :param jira.client.JIRA client: JIRA Client
     :param jira.resources.Issue existing: Existing JIRA issue that was found
     :param String new_comment: Formatted comment we're looking for
@@ -78,7 +94,6 @@ def comment_exists(client, existing, new_comment):
         if new_comment == comment.body:
             # If the comment was
             return True
-
     return False
 
 
@@ -96,12 +111,17 @@ def update_jira_issue(existing, pr, client):
 
     # Format and add comment to indicate PR has been linked
     new_comment = format_comment(pr, pr.suffix, client)
-    # See if the comment exists
-    exists = comment_exists(client, existing, new_comment)
+    # See if the issue_link and comment exists
+    exists = issue_link_exists(client, existing, pr)
+    comment_exist = comment_exists(client, existing, new_comment)
     # Check if the comment if already there
     if not exists:
-        log.info(f"Added comment for PR {pr.title} on JIRA {pr.jira_key}")
-        client.add_comment(existing, new_comment)
+        if not comment_exist:
+            log.info(f"Added comment for PR {pr.title} on JIRA {pr.jira_key}")
+            client.add_comment(existing, new_comment)
+        # Attach remote link
+        remote_link = dict(url=pr.url, title=f"[PR] {pr.title}")
+        d_issue.attach_link(client, existing, remote_link)
         if confluence_client.update_stat:
             confluence_data = {'Comments': 1}
             confluence_client.update_stat_page(confluence_data)

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -330,7 +330,7 @@ class TestDownstreamIssue(unittest.TestCase):
 
     @mock.patch(PATH + 'confluence_client')
     @mock.patch(PATH + '_update_jira_issue')
-    @mock.patch(PATH + '_attach_link')
+    @mock.patch(PATH + 'attach_link')
     @mock.patch('jira.client.JIRA')
     def test_create_jira_issue(self,
                                mock_client,
@@ -389,7 +389,7 @@ class TestDownstreamIssue(unittest.TestCase):
 
     @mock.patch(PATH + 'confluence_client')
     @mock.patch(PATH + '_update_jira_issue')
-    @mock.patch(PATH + '_attach_link')
+    @mock.patch(PATH + 'attach_link')
     @mock.patch('jira.client.JIRA')
     def test_create_jira_issue_failed_epic_link(self,
                                                 mock_client,
@@ -449,7 +449,7 @@ class TestDownstreamIssue(unittest.TestCase):
 
     @mock.patch(PATH + 'confluence_client')
     @mock.patch(PATH + '_update_jira_issue')
-    @mock.patch(PATH + '_attach_link')
+    @mock.patch(PATH + 'attach_link')
     @mock.patch('jira.client.JIRA')
     def test_create_jira_issue_failed_exd_service(self,
                                                   mock_client,
@@ -512,7 +512,7 @@ class TestDownstreamIssue(unittest.TestCase):
 
     @mock.patch(PATH + 'confluence_client')
     @mock.patch(PATH + '_update_jira_issue')
-    @mock.patch(PATH + '_attach_link')
+    @mock.patch(PATH + 'attach_link')
     @mock.patch('jira.client.JIRA')
     def test_create_jira_issue_no_updates(self,
                                           mock_client,


### PR DESCRIPTION
~~Testing on Stage prior to master~~
Tested on Stage and everything went as expected. 
From the original issue:

> It would be cool when we link a PR we add the PR URL to issue_links on JIRA
> Taking this Issue. also we need to check against issue_links, instead of just looking for a matching comment. I noticed that sometimes we could double comment when a user would remove the WIP title.