### PR TITLE
Use jira format and gfm when converting desc

### DIFF
--- a/docs/source/config-file.rst
+++ b/docs/source/config-file.rst
@@ -141,7 +141,7 @@ The config file is made up of multiple parts
     * :code:`{'on_close': {'apply_lables': ['label', ...]}}`
         * When the upstream issue is closed, apply additional labels on the corresponding Jira ticket.
     * :code:`github_markdown`
-        * If description syncing is turned on, this flag will convert Github markdown to plaintext. This uses the pypandoc module.
+        * If description syncing is turned on, this flag will convert Github markdown to Jira syntax. This uses the pypandoc module.
     * :code:`upstream_id`
         * If selected this will add a comment to all newly created JIRA issue in the format 'UPSTREAM_PROJECT-#1' where the number indicates the issue ID. This allows users to search for the issue on JIRA via the issue number.
     * :code:`url`

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1280,7 +1280,7 @@ def sync_with_jira(issue, config):
     if issue.downstream.get('issue_updates', None):
         if issue.source == 'github' and issue.content and \
                 'github_markdown' in issue.downstream['issue_updates']:
-            issue.content = pypandoc.convert_text(issue.content, 'plain', format='md')
+            issue.content = pypandoc.convert_text(issue.content, 'jira', format='gfm')
 
     # First, check to see if we have a matching issue using the new method.
     # If we do, then just bail out.  No sync needed.


### PR DESCRIPTION
While syncing an issue to Jira, if the `github_markdown` option is listed in `issue_updates`, and the upstream issue is from GitHub, then use the proper GitHub-Flavored Markdown parser (`gfm`) and covert it to the `jira` format instead of `plain` text.

This improves how things like links and code blocks are represented in the created Jira issue.