### PR TITLE
implement a debug logging config option

### DIFF
--- a/docs/source/config-file.rst
+++ b/docs/source/config-file.rst
@@ -16,10 +16,9 @@ The config file is made up of multiple parts
 
 .. code-block:: python
 
-    'initialize': True
+    'debug': False
 
-* Initialization set to True will ensure that there is an initial sync done when Sync2Jira starts.
-  It is recommended to leave this as True to ensure that all issues are in sync.
+* Enable or disable debugging output. This will emit on fedmsg messages and can be very noisy; not for production use.
 
 .. code-block:: python
 

--- a/fedmsg.d/sync2jira.py
+++ b/fedmsg.d/sync2jira.py
@@ -25,6 +25,9 @@ config = {
         # Mailing list email to send failure-email notices too
         'mailing-list': 'some_email@demo.com',
 
+        # Enable debug logging
+        'debug': False,
+
         # Listen on the message bus
         'listen': True,
 

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -50,14 +50,6 @@ logging.basicConfig(format=FORMAT, level=logging.INFO)
 logging.basicConfig(format=FORMAT, level=logging.DEBUG)
 logging.basicConfig(format=FORMAT, level=logging.WARNING)
 log = logging.getLogger('sync2jira')
-if os.environ.get('CONFLUENCE_SPACE') == 'mock_confluence_space':
-    # If we are debugging save log output
-    try:
-        hdlr = logging.FileHandler('sync2jira_main.log')
-        log.addHandler(hdlr)
-        log.setLevel(logging.DEBUG)
-    except:  # noqa: E722
-        log.error("Unable to create log file!")
 
 # Only allow fedmsg logs that are critical
 fedmsg_log = logging.getLogger('fedmsg.crypto.utils')
@@ -122,6 +114,12 @@ def load_config(loader=fedmsg.config.load_config):
 
     # Force some vars that we like
     config['mute'] = True
+
+    # debug mode
+    if config['sync2jira']['debug']:
+        hdlr = logging.FileHandler('sync2jira_main.log')
+        log.addHandler(hdlr)
+        log.setLevel(logging.DEBUG)
 
     # Validate it
     if 'sync2jira' not in config:


### PR DESCRIPTION
Add a _required_ `debug` option to the configuration file. It will turn on or off debugging output.