### PR TITLE
Doc delinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,3 @@ On startup:
 - if the `INITIALIZE` environment variable is set to `1`, the script will sync all issues to Jira. Use caution as this may be very expensive and difficult to undo.
 
 Please look at our documentation [here](https://sync2jira.readthedocs.io/en/master/config-file.html) for a full list of what can be synced and how to set it up.
-
-## Branches
-
-We will maintain three branches
-
-1. `master` - This will be where our main code and most up-to-date code lives
-1. `stage` - This will be our staging configuration. PR's will merge through stage to master
-1. `openshift-build` - This branch will maintain OpenShift-Build related information

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ## What is Sync2Jira?
 
-This is a process that listens to activity on upstream repos on pagure and
-github via fedmsg, and syncs new issues there to a Jira instance elsewhere.
+This is a process that listens to activity on upstream repos on Pagure and
+GitHub via fedmsg, and syncs new issues there to a Jira instance elsewhere.
 
 ## Documentation
 
@@ -21,7 +21,9 @@ We have set up a quick-start [here](https://sync2jira.readthedocs.io/en/master/q
 
 Configuration is in folder `fedmsg.d`.
 
-You can maintain a mapping there that allows you to match one upstream repo (say, 'pungi' on pagure) to a downstream project/component pair in Jira (say, 'COMPOSE', and 'Pungi').
+You can maintain a mapping there that allows you to match one upstream repo
+(say, 'pungi' on Pagure) to a downstream project/component pair in Jira (say,
+'COMPOSE', and 'Pungi').
 
 On startup:
 
@@ -34,6 +36,6 @@ Please look at our documentation [here](https://sync2jira.readthedocs.io/en/mast
 
 We will maintain three branches
 
-1. `master` - This will be where our main code and most up to date code lives
+1. `master` - This will be where our main code and most up-to-date code lives
 1. `stage` - This will be our staging configuration. PR's will merge through stage to master
 1. `openshift-build` - This branch will maintain OpenShift-Build related information

--- a/docs/source/adding-new-repo-guide.rst
+++ b/docs/source/adding-new-repo-guide.rst
@@ -6,16 +6,16 @@ Have you ever wanted to add new upstream repos? Well now you can!
 1. First ensure that your upstream repo is on the Fed Message Bus
 2. Now add two new functions to `sync2jira/upstream_pr.py` and `sync2jira/upstream_issue.py`
     * :code:`def hande_REPO-NAME_message(msg, config)`
-        * This function will take in a fedmessage message (msg) and the config dict
-        * This function will return a sync2jira.Intermediary.Issue object
+        * This function will take in a fedmessage message (`msg`) and the config dict
+        * This function will return a :code:`sync2jira.Intermediary.Issue` object
         * This function will be used when listening to the message bus
     * :code:`def REPO-NAME_issues(upstream, config)`
         * This function will take in an upstream repo name and the config dict 
-        * This function will return a generator of sync2jira.Intermediary.Issue objects that contain all upstream Issues
+        * This function will return a generator of :code:`sync2jira.Intermediary.Issue` objects that contain all upstream Issues
         * This function will be used to initialize and sync upstream/downstream issues
 3. Now modify the `sync2jira/main.py` functions: 
-    * :code:`def initialize_pr(config, ...)` and `def initialize_issues(config, ...)`
-        * Add another section (like Pagure and GitHub) to utlize the :code:`REPO-NAME_issues` function you just made. 
+    * :code:`def initialize_pr(config, ...)` and :code:`def initialize_issues(config, ...)`
+        * Add another section (like Pagure and GitHub) to utilize the :code:`REPO-NAME_issues` function you just made.
     * :code:`def listen(config)`
         * Add another section to the if statement under Pagure and GitHub
             * :code:`elif 'REPO-NAME' in suffix:`

--- a/docs/source/config-file.rst
+++ b/docs/source/config-file.rst
@@ -59,7 +59,7 @@ The config file is made up of multiple parts
     },
 
 * Here you can configure multiple JIRA instances if you have projects with differing downstream JIRA instances.
-  Ensure to name them approproialty, in name of the JIRA instance above is `example`.
+  Ensure to name them appropriately, in name of the JIRA instance above is `example`.
 
 .. code-block:: python
 
@@ -96,7 +96,7 @@ The config file is made up of multiple parts
     * :code:`'type'`
         * Optional: Set the issue type that will be created. The default is Bug.
     * :code:`'issue_type': {'bug': 'Bug', 'enhancement': 'Story'}`
-        * Optional: Set the issue type based on github labels. If none match, fall back to what :code:`type` is set to.
+        * Optional: Set the issue type based on GitHub labels. If none match, fall back to what :code:`type` is set to.
    * :code:`'EXD-Service': {'guild': 'SOME_GUILD', 'value': 'SOME_VALUE'}`
         * Sync custom EXD-Service field
 
@@ -104,8 +104,9 @@ The config file is made up of multiple parts
 
             :pullrequest: After enabling PR syncing, just type "Relates to JIRA: XXXX-1234" in the comment or description of the PR to sync with a JIRA issue. After this, updates such as when it has been merged will automatically be added to the JIRA ticket.
 
-* You can add your projects here. The 'project' field is associated with downstream JIRA projects, and 'component' with downstream components
-  You can add the following to the :code:`issue_updates` array:
+* You can add your projects here. The :code:`'project'` field is associated
+  with downstream JIRA projects, and :code:`'component'` with downstream
+  components.  You can add the following to the :code:`issue_updates` array:
 
     * :code:`'comments'`
         * Sync comments and comment edits
@@ -121,7 +122,7 @@ The config file is made up of multiple parts
         * Sync title
     * :code:`{'transition': True/'CUSTOM_TRANSITION'}`
         * Sync status (open/closed), Sync only status/Attempt to transition JIRA ticket to CUSTOM_TRANSITION on upstream closure
-    * :code:`{'on_close': {'apply_lables': ['label', ...]}}`
+    * :code:`{'on_close': {'apply_labels': ['label', ...]}}`
         * When the upstream issue is closed, apply additional labels on the corresponding Jira ticket.
     * :code:`github_markdown`
         * If description syncing is turned on, this flag will convert Github markdown to Jira syntax. This uses the pypandoc module.
@@ -133,7 +134,7 @@ The config file is made up of multiple parts
     .. note::
 
         :Overwrite: Setting this to :code:`True` will ensure that Upstream (GitHub or Pagure) values will overwrite downstream ones (i.e. if its empty upstream it'll be empty downstream)
-        :CUSTOM_TRANSITION: Setting this value will get Sync2Jira to automatially transition downstream tickets once their upstream counterparts get closed. Set this to whatever 'closed' means downstream.
+        :CUSTOM_TRANSITION: Setting this value will get Sync2Jira to automatically transition downstream tickets once their upstream counterparts get closed. Set this to whatever 'closed' means downstream.
 
 * You can add your projects here. The 'project' field is associated with downstream JIRA projects, and 'component' with downstream components
   You can add the following to the :code:`pr_updates` array:
@@ -146,7 +147,7 @@ The config file is made up of multiple parts
 * You can add the following to the mapping array. This array will map an upstream field to the downstream counterpart with XXX replaced.
 
     * :code:`{'fixVersion': 'Test XXX'}`
-        * Maps upstream milestone (suppose it's called 'milesone') to downstream fixVersion with a mapping (for our example it would be 'Test milesone')
+        * Maps upstream milestone (suppose it's called 'milestone') to downstream fixVersion with a mapping (for our example it would be 'Test milestone')
 
 * It is strongly encouraged for teams to use the :code:`owner` field. If configured, owners will be alerted if Sync2Jira finds duplicate downstream issues.
   Further the owner will be used as a default in case the program is unable to find a valid assignee.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,7 +10,7 @@ Want to quickly get started working with Sync2Jira? Follow these steps:
 
         'github_token': 'YOUR_TOKEN',
 
-3. Enter relevent JIRA information
+3. Enter relevant JIRA information
     .. code-block:: python
 
         'default_jira_instance': 'example',


### PR DESCRIPTION
Reading through the _Sync2Jira_ docs, I noticed a few typos/misspellings, and I noted a couple of formatting glitches, and then, when I checked out a branch, my IDE pointed out a few more....  This PR endeavors to fix the typos that I found, and, where my changes hit long lines, I wrapped them to 80 columns to make future reviews easier (but, I left unchanged lines unchanged).

Also, in a separate commit, I removed the **Branches** section from the `README.md`:  it looks completely out of date, and I figured that removing it was better than trying to fix it.  Let me know if you want it restored and/or amended.