### PR TITLE
Refactoring upstream code to DRY it out a bit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+arrow
 jira
 requests
 requests_kerberos

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -261,7 +261,7 @@ def alert_user_of_duplicate_issues(issue, final_result, results_of_query,
     admins = []
     admin_template = []
     for admin in config['sync2jira']['admins']:
-        admin_username = [name for name in admin][0]
+        admin_username = next(name for name in admin).strip()
         ret = client.search_users(admin_username)
         if len(ret) > 1:
             log.warning('Found multiple users for admin %s', admin_username)
@@ -808,7 +808,7 @@ def _update_transition(client, existing, issue):
     # downstream JIRA ticket
 
     # First get the closed status from the config file
-    closed_status = list(filter(lambda d: "transition" in d, issue.downstream.get('issue_updates', {})))[0]['transition']
+    closed_status = next(filter(lambda d: "transition" in d, issue.downstream.get('issue_updates', {})))['transition']
     if closed_status is not True and issue.status == 'Closed' \
             and existing.fields.status.name.upper() != closed_status.upper():
         # Now we need to update the status of the JIRA issue
@@ -869,7 +869,7 @@ def _update_fixVersion(updates, existing, issue, client):
     """
     fix_version = []
     # If we are not supposed to overwrite JIRA content
-    if not bool(list(filter(lambda d: "fixVersion" in d, updates))[0]['fixVersion']['overwrite']):
+    if not bool(next(filter(lambda d: "fixVersion" in d, updates))['fixVersion']['overwrite']):
         # We need to make sure we're not deleting any fixVersions on JIRA
         # Get all fixVersions for the issue
         for version in existing.fields.fixVersions:
@@ -915,7 +915,7 @@ def _update_assignee(client, existing, issue, updates):
         :returns: Nothing
     """
     # First check if overwrite is set to True
-    overwrite = bool(list(filter(lambda d: "assignee" in d, updates))[0]['assignee']['overwrite'])
+    overwrite = bool(next(filter(lambda d: "assignee" in d, updates))['assignee']['overwrite'])
 
     # First check if the issue is already assigned to the same person
     update = False
@@ -1046,7 +1046,7 @@ def _update_tags(updates, existing, issue):
     updated_labels = issue.tags
 
     # Ensure no duplicates if overwrite is set to false
-    if not bool(list(filter(lambda d: "tags" in d, updates))[0]['tags']['overwrite']):
+    if not bool(next(filter(lambda d: "tags" in d, updates))['tags']['overwrite']):
         updated_labels = _label_matching(updated_labels, existing.fields.labels)
 
     # Ensure that the tags are all valid

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -975,6 +975,10 @@ def _update_github_project_fields(client, existing, issue,
 
     default_jira_fields = config['sync2jira'].get('default_jira_fields', {})
     for name, values in github_project_fields.items():
+        if name not in dir(issue):
+            log.error(f"Configuration error: github_project_field key, {name:r}, is not in issue object.")
+            continue
+
         log.info(f"Looking at GHP field '{name}' with configuration '{values}'")
         fieldvalue = getattr(issue, name)
         log.info(f"Issue value for field '{name}' is '{fieldvalue}'")

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -17,18 +17,17 @@
 #
 # Authors:  Ralph Bean <rbean@redhat.com>
 
-# Build-In Modules
-import operator
-import logging
-import re
+# Python Standard Library Modules
+from datetime import datetime, timezone
 import difflib
+import logging
+import operator
+import re
 
 # 3rd Party Modules
 import arrow
-import jira.client
 from jira import JIRAError
-from datetime import datetime
-from zoneinfo import ZoneInfo
+import jira.client
 import jinja2
 import pypandoc
 
@@ -38,8 +37,7 @@ from sync2jira.mailer import send_mail
 
 # The date the service was upgraded
 # This is used to ensure legacy comments are not touched
-UTC = ZoneInfo(key='UTC')
-UPDATE_DATE = datetime(2019, 7, 9, 18, 18, 36, 480291, UTC)
+UPDATE_DATE = datetime(2019, 7, 9, 18, 18, 36, 480291, tzinfo=timezone.utc)
 
 log = logging.getLogger('sync2jira')
 

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -146,7 +146,7 @@ def update_transition(client, existing, pr, transition_type):
     :returns: Nothing
     """
     # Get our closed status
-    closed_status = list(filter(lambda d: transition_type in d, pr.downstream.get('pr_updates', {})))[0][transition_type]
+    closed_status = next(filter(lambda d: transition_type in d, pr.downstream.get('pr_updates', {})))[transition_type]
 
     # Update the state
     d_issue.change_status(client, existing, closed_status, pr)

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -229,7 +229,7 @@ def map_fixVersion(mapping, issue):
     :param Dict issue: Upstream issue object
     """
     # Get our fixVersion mapping
-    fixVersion_map = list(filter(lambda d: "fixVersion" in d, mapping))[0]['fixVersion']
+    fixVersion_map = next(filter(lambda d: "fixVersion" in d, mapping))['fixVersion']
 
     # Now update the fixVersion
     if issue['milestone']:

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -113,7 +113,7 @@ class Issue(object):
         )
 
     def __repr__(self):
-        return "<Issue %s >" % self.url
+        return f"<Issue {self.url} >"
 
 
 class PR(object):

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -36,7 +36,7 @@ class Issue(object):
         self.storypoints = storypoints
 
         # First trim the size of the content
-        self.content = trimString(content)
+        self.content = trim_string(content)
 
         # JIRA treats utf-8 characters in ways we don't totally understand, so scrub content down to
         # simple ascii characters right from the start.
@@ -73,7 +73,7 @@ class Issue(object):
             comments.append({
                 'author': comment['author'],
                 'name': comment['name'],
-                'body': trimString(comment['body']),
+                'body': trim_string(comment['body']),
                 'id': comment['id'],
                 'date_created': comment['date_created'],
                 'changed': None
@@ -136,7 +136,7 @@ class PR(object):
         # simple ascii characters right from the start.
         if content:
             # First trim the size of the content
-            self.content = trimString(content)
+            self.content = trim_string(content)
 
             self.content = self.content.encode('ascii', errors='replace').decode('ascii')
 
@@ -164,7 +164,7 @@ class PR(object):
         return u'[%s] %s' % (self.upstream, self._title)
 
     @classmethod
-    def from_github(self, upstream, pr, suffix, config):
+    def from_github(cls, upstream, pr, suffix, config):
         """Helper function to create intermediary object."""
         # Set our upstream source
         upstream_source = 'github'
@@ -175,7 +175,7 @@ class PR(object):
             comments.append({
                 'author': comment['author'],
                 'name': comment['name'],
-                'body': trimString(comment['body']),
+                'body': trim_string(comment['body']),
                 'id': comment['id'],
                 'date_created': comment['date_created'],
                 'changed': None
@@ -198,7 +198,7 @@ class PR(object):
                 suffix = 'closed'
 
         # Return our PR object
-        return PR(
+        return cls(
             source=upstream_source,
             jira_key=match,
             title=pr['title'],
@@ -266,7 +266,7 @@ def matcher(content, comments):
             return None
 
 
-def trimString(content):
+def trim_string(content):
     """
     Helper function to trim a string to ensure it is not over 50000 char
     Ref: https://github.com/release-engineering/Sync2Jira/issues/123

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -87,7 +87,7 @@ DATAGREPPER_URL = "http://apps.fedoraproject.org/datagrepper/raw"
 INITIALIZE = os.getenv('INITIALIZE', '0')
 
 
-def load_config(loader=fedmsg.config.load_config):
+def load_config(loader=fedmsg.config.conf.load_config):
     """
     Generates and validates the config file \
     that will be used by fedmsg and JIRA client.
@@ -103,8 +103,8 @@ def load_config(loader=fedmsg.config.load_config):
 
     # debug mode
     if config.get('sync2jira', {}).get('debug', False):
-        hdlr = logging.FileHandler('sync2jira_main.log')
-        log.addHandler(hdlr)
+        handler = logging.FileHandler('sync2jira_main.log')
+        log.addHandler(handler)
         log.setLevel(logging.DEBUG)
 
     # Validate it
@@ -193,8 +193,8 @@ def initialize_issues(config, testing=False, repo_name=None):
                     raise
         except Exception as e:
             if "API rate limit exceeded" in e.__str__():
-                # If we've hit out API limit:
-                # Sleep for 1 hour and call our function again
+                # If we've hit our API limit, sleep for 1 hour, and call our
+                # function again.
                 log.info("Hit Github API limit. Sleeping for 1 hour...")
                 sleep(3600)
                 if not testing:
@@ -239,8 +239,8 @@ def initialize_pr(config, testing=False, repo_name=None):
                     raise
         except Exception as e:
             if "API rate limit exceeded" in e.__str__():
-                # If we've hit out API limit:
-                # Sleep for 1 hour and call our function again
+                # If we've hit our API limit, sleep for 1 hour, and call our
+                # function again.
                 log.info("Hit Github API limit. Sleeping for 1 hour...")
                 sleep(3600)
                 if not testing:
@@ -282,14 +282,14 @@ def initialize_recent(config):
 
 def handle_msg(msg, suffix, config):
     """
-    Function to handle incomming message from datagrepper
+    Function to handle incoming message from datagrepper
     :param Dict msg: Incoming message
     :param String suffix: Incoming suffix
     :param Dict config: Config dict
     """
     issue = None
     pr = None
-    # Github '.issue.' is used for both PR and Issue
+    # GitHub '.issue.' is used for both PR and Issue
     # Check for that edge case
     if suffix == 'github.issue.comment':
         if 'pull_request' in msg['msg']['issue'] and msg['msg']['action'] != 'deleted':
@@ -364,7 +364,7 @@ def get(params):
 def main(runtime_test=False, runtime_config=None):
     """
     Main function to check for initial sync
-    and listen for fedmgs.
+    and listen for fedmsgs.
 
     :param Bool runtime_test: Flag to indicate if we are performing a runtime test. Default false
     :param Dict runtime_config: Config file to be used if it is a runtime test. runtime_test must be true
@@ -388,7 +388,7 @@ def main(runtime_test=False, runtime_config=None):
             if runtime_test:
                 return
         else:
-            # Pool datagrepper from the last 10 mins
+            # Pull from datagrepper for the last 10 minutes
             log.info("Initialization False. Pulling data from datagrepper...")
             initialize_recent(config)
         try:
@@ -406,14 +406,13 @@ def report_failure(config):
     """
     Helper function to alert admins in case of failure.
 
-
     :param Dict config: Config dict for JIRA
     """
     # Email our admins with the traceback
-    templateLoader = jinja2.FileSystemLoader(
+    template_loader = jinja2.FileSystemLoader(
         searchpath='usr/local/src/sync2jira/sync2jira/')
-    templateEnv = jinja2.Environment(loader=templateLoader, autoescape=True)
-    template = templateEnv.get_template('failure_template.jinja')
+    template_env = jinja2.Environment(loader=template_loader, autoescape=True)
+    template = template_env.get_template('failure_template.jinja')
     html_text = template.render(traceback=traceback.format_exc())
 
     # Send mail

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -327,9 +327,6 @@ def query(limit=None, **kwargs):
     # Pack up the kwargs into a parameter list for request
     params = deepcopy(kwargs)
 
-    # Set up for paging requests
-    all_results = []
-
     # Important to set ASC order when paging to avoid duplicates
     params['order'] = 'asc'
 
@@ -349,10 +346,10 @@ def query(limit=None, **kwargs):
         if count == 0:
             break
 
-        all_results.extend(results['raw_messages'])
-        params['page'] = params.get('page', 1) + 1
+        for result in results['raw_messages']:
+            yield result
 
-    return all_results
+        params['page'] = params.get('page', 1) + 1
 
 
 def get(params):

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -87,7 +87,7 @@ DATAGREPPER_URL = "http://apps.fedoraproject.org/datagrepper/raw"
 INITIALIZE = os.getenv('INITIALIZE', '0')
 
 
-def load_config(loader=fedmsg.config.conf.load_config):
+def load_config(loader=lambda: fedmsg.config.conf):
     """
     Generates and validates the config file \
     that will be used by fedmsg and JIRA client.

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -119,8 +119,8 @@ def load_config(loader=fedmsg.config.load_config):
     if not specified.issubset(possible):
         message = "Specified handlers: %s, must be a subset of %s."
         raise ValueError(message % (
-            ", ".join(['"%s"' % item for item in specified]),
-            ", ".join(['"%s"' % item for item in possible]),
+            ", ".join(f'"{item}"' for item in specified),
+            ", ".join(f'"{item}"' for item in possible),
         ))
 
     if 'jira' not in config['sync2jira']:

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -417,9 +417,9 @@ def get_all_github_data(url, headers):
     """ Pagination utility.  Obnoxious. """
     link = dict(next=url)
     while 'next' in link:
-        response = _fetch_github_data(link['next'], headers)
+        response = api_call_get(link['next'], headers=headers)
         for issue in response.json():
-            comments = _fetch_github_data(issue['comments_url'], headers)
+            comments = api_call_get(issue['comments_url'], headers=headers)
             issue['comments'] = comments.json()
             yield issue
         link = _github_link_field_to_dict(response.headers.get('link', None))
@@ -441,12 +441,11 @@ def _github_link_field_to_dict(field):
     ])
 
 
-def _fetch_github_data(url, headers):
-    """
-        Helper function to gather GitHub data
-    """
-    response = requests.get(url, headers=headers)
+def api_call_get(url, **kwargs):
+    """Helper function to encapsulate a REST API GET call"""
+    response = requests.get(url, **kwargs)
     if not bool(response):
+        # noinspection PyBroadException
         try:
             reason = response.json()
         except Exception:

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -378,8 +378,8 @@ def _get_current_project_node(upstream, project_number, issue_number, gh_issue):
 
 
 def get_all_github_data(url, headers):
-    """ Pagination utility.  Obnoxious. """
-    link = dict(next=url)
+    """A generator which returns each response from a paginated GitHub API call"""
+    link = {'next': url}
     while 'next' in link:
         response = api_call_get(link['next'], headers=headers)
         for issue in response.json():
@@ -390,19 +390,16 @@ def get_all_github_data(url, headers):
 
 
 def _github_link_field_to_dict(field):
-    """
-        Utility for ripping apart github's Link header field.
-        It's kind of ugly.
-    """
+    """Utility for ripping apart GitHub's Link header field."""
 
     if not field:
-        return dict()
-    return dict([
+        return {}
+    return dict(
         (
             part.split('; ')[1][5:-1],
-            part.split('; ')[0][1:-1],
+            part.split('; ')[0][1:-1]
         ) for part in field.split(', ')
-    ])
+    )
 
 
 def api_call_get(url, **kwargs):

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -151,7 +151,7 @@ def handle_github_message(msg, config, pr_filter=True):
                 return None
         elif key == 'milestone':
             # special handling for milestone: use the number
-            milestone = issue.get(key) or {}
+            milestone = issue.get(key, {})
             actual = milestone.get('number')
             if expected != actual:
                 log.debug("Milestone %s not set on issue: %s", expected, upstream)
@@ -164,10 +164,9 @@ def handle_github_message(msg, config, pr_filter=True):
                           key, actual, expected, upstream)
                 return None
 
-    if pr_filter and 'pull_request' in issue:
-        if not issue.get('closed_at'):
-            log.debug("%r is a pull request.  Ignoring.", issue.get('html_url'))
-            return None
+    if pr_filter and 'pull_request' in issue and 'closed_at' not in issue:
+        log.debug("%r is a pull request.  Ignoring.", issue.get('html_url', '<missing URL>'))
+        return None
 
     github_client = Github(config['sync2jira']['github_token'], retry=5)
     reformat_github_issue(issue, upstream, github_client)
@@ -387,7 +386,7 @@ def get_all_github_data(url, headers):
             comments = api_call_get(issue['comments_url'], headers=headers)
             issue['comments'] = comments.json()
             yield issue
-        link = _github_link_field_to_dict(response.headers.get('link', None))
+        link = _github_link_field_to_dict(response.headers.get('link'))
 
 
 def _github_link_field_to_dict(field):

--- a/sync2jira/upstream_pr.py
+++ b/sync2jira/upstream_pr.py
@@ -19,12 +19,6 @@
 
 import logging
 
-try:
-    string_type = str
-except ImportError:
-    import types
-    string_type = types.StringTypes
-
 from github import Github
 
 import sync2jira.intermediary as i

--- a/sync2jira/upstream_pr.py
+++ b/sync2jira/upstream_pr.py
@@ -87,47 +87,7 @@ def reformat_github_pr(pr, upstream, github_client):
     else:
         # We have multiple comments and need to make api call to get them
         repo = github_client.get_repo(upstream)
-        comments = []
         github_pr = repo.get_pull(number=pr['number'])
-        for comment in github_pr.get_issue_comments():
-            # First make API call to get the users name
-            comments.append({
-                'author': comment.user.name or comment.user.login,
-                'name': comment.user.login,
-                'body': comment.body,
-                'id': comment.id,
-                'date_created': comment.created_at,
-                'changed': None
-            })
-        # Assign the message with the newly formatted comments :)
-        pr['comments'] = comments
+        pr['comments'] = u_issue.reformat_github_comments(github_pr.get_issue_comments())
 
-    # Update reporter:
-    # Search for the user
-    reporter = github_client.get_user(pr['user']['login'])
-    # Update the reporter field in the message (to match Pagure format)
-    if reporter.name:
-        pr['user']['fullname'] = reporter.name
-    else:
-        pr['user']['fullname'] = pr['user']['login']
-
-    # Update assignee(s):
-    assignees = []
-    for person in pr.get('assignees', []):
-        assignee = github_client.get_user(person['login'])
-        assignees.append({'fullname': assignee.name})
-    # Update the assignee field in the message (to match Pagure format)
-    pr['assignees'] = assignees
-
-    # Update the label field in the message (to match Pagure format)
-    if pr['labels']:
-        # Loop through all the labels on GitHub and add them
-        # to the new label list and then reassign the message
-        new_label = []
-        for label in pr['labels']:
-            new_label.append(label['name'])
-        pr['labels'] = new_label
-
-    # Update milestone:
-    if pr.get('milestone'):
-        pr['milestone'] = pr['milestone']['title']
+    u_issue.reformat_github_common(pr, github_client)

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1,8 +1,7 @@
 import unittest
 import unittest.mock as mock
 from unittest.mock import MagicMock
-from datetime import datetime
-from zoneinfo import ZoneInfo
+from datetime import datetime, timezone
 
 import sync2jira.downstream_issue as d
 from sync2jira.intermediary import Issue
@@ -11,8 +10,6 @@ import jira.client
 from jira import JIRAError
 
 PATH = 'sync2jira.downstream_issue.'
-
-UTC = ZoneInfo(key='UTC')
 
 
 class TestDownstreamIssue(unittest.TestCase):
@@ -1494,7 +1491,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_jira_comment.raw = {'body': 'mock_legacy_comment_body'}
         mock_comment = {
             'id': '12345',
-            'date_created': datetime(2019, 8, 8, 0, 0, 0, 0, UTC)
+            'date_created': datetime(2019, 8, 8, tzinfo=timezone.utc)
         }
 
         # Call the function
@@ -1520,7 +1517,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_jira_comment.raw = {'body': '12345'}
         mock_comment = {
             'id': '12345',
-            'date_created': datetime(2019, 8, 8, 0, 0, 0, 0, UTC)
+            'date_created': datetime(2019, 8, 8, tzinfo=timezone.utc)
         }
 
         # Call the function
@@ -1546,7 +1543,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_jira_comment.raw = {'body': 'old_comment'}
         mock_comment = {
             'id': '12345',
-            'date_created': datetime(2019, 1, 1, 0, 0, 0, 0, UTC)
+            'date_created': datetime(2019, 1, 1, tzinfo=timezone.utc)
         }
 
         # Call the function
@@ -1570,7 +1567,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_comment_format_legacy.return_value = 'mock_legacy_comment_body'
         mock_comment = {
             'id': '12345',
-            'date_created': datetime(2019, 1, 1, 0, 0, 0, 0, UTC)
+            'date_created': datetime(2019, 1, 1, tzinfo=timezone.utc)
         }
 
         # Call the function

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -496,7 +496,8 @@ class TestMain(unittest.TestCase):
         response = m.query()
 
         # Assert everything was called correctly
-        mock_get.assert_called_with(params={'order': 'asc'})
+        mock_get.assert_called_once()
+        self.assertEqual(mock_get.call_args.kwargs['params']['order'], 'asc')
         self.assertEqual(response, ['test_msg'])
 
     @mock.patch(PATH + 'HTTPKerberosAuth')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -493,7 +493,7 @@ class TestMain(unittest.TestCase):
             'total': 1
         }
         # Call the function
-        response = m.query()
+        response = list(m.query())
 
         # Assert everything was called correctly
         mock_get.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,7 +54,7 @@ class TestMain(unittest.TestCase):
         loader = lambda: {'sync2jira': {}}
         self._check_for_exception(loader, 'No sync2jira.map section')
 
-    def test_config_validate_mispelled_mappings(self):
+    def test_config_validate_misspelled_mappings(self):
         loader = lambda: {'sync2jira': {'map': {'githob': {}}}, 'jira': {}}
         self._check_for_exception(loader, 'Specified handlers: "githob", must')
 
@@ -64,7 +64,7 @@ class TestMain(unittest.TestCase):
 
     def test_config_validate_all_good(self):
         loader = lambda: {'sync2jira': {'map': {'github': {}}, 'jira': {}}}
-        m.load_config(loader)  # ahhh, no exception.
+        m.load_config(loader)  # Should succeed without an exception.
 
     @mock.patch(PATH + 'u_issue')
     @mock.patch(PATH + 'd_issue')
@@ -366,13 +366,13 @@ class TestMain(unittest.TestCase):
         Tests 'report_failure' function
         """
         # Set up return values
-        mock_templateLoader = MagicMock()
-        mock_templateEnv = MagicMock()
+        mock_template_loader = MagicMock()
+        mock_template_env = MagicMock()
         mock_template = MagicMock()
         mock_template.render.return_value = 'mock_html'
-        mock_templateEnv.get_template.return_value = mock_template
-        mock_jinja2.FileSystemLoader.return_value = mock_templateLoader
-        mock_jinja2.Environment.return_value = mock_templateEnv
+        mock_template_env.get_template.return_value = mock_template
+        mock_jinja2.FileSystemLoader.return_value = mock_template_loader
+        mock_jinja2.Environment.return_value = mock_template_env
 
         # Call the function
         m.report_failure({'sync2jira': {'mailing-list': 'mock_email'}})

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -597,11 +597,11 @@ class TestUpstreamIssue(unittest.TestCase):
         self.mock_github_issue.get_comments.assert_any_call()
         self.mock_github_client.get_user.assert_called_with('mock_login')
 
-    @mock.patch(PATH + '_fetch_github_data')
+    @mock.patch(PATH + 'api_call_get')
     @mock.patch(PATH + '_github_link_field_to_dict')
     def test_get_all_github_data(self,
                                  mock_github_link_field_to_dict,
-                                 mock_fetch_github_data):
+                                 mock_api_call_get):
         """
         This tests the '_get_all_github_data' function
         """
@@ -609,7 +609,7 @@ class TestUpstreamIssue(unittest.TestCase):
         get_return = MagicMock()
         get_return.json.return_value = [{'comments_url': 'mock_comments_url'}]
         get_return.headers = {'link': 'mock_link'}
-        mock_fetch_github_data.return_value = get_return
+        mock_api_call_get.return_value = get_return
 
         # Call the function
         response = list(u.get_all_github_data(
@@ -618,16 +618,15 @@ class TestUpstreamIssue(unittest.TestCase):
         ))
 
         # Assert everything was called correctly
-        mock_fetch_github_data.assert_any_call('mock_url', 'mock_headers')
-        mock_fetch_github_data.assert_any_call('mock_comments_url', 'mock_headers')
+        mock_api_call_get.assert_any_call('mock_url', headers='mock_headers')
+        mock_api_call_get.assert_any_call('mock_comments_url', headers='mock_headers')
         mock_github_link_field_to_dict.assert_called_with('mock_link')
         self.assertEqual('mock_comments_url', response[0]['comments_url'])
 
     @mock.patch(PATH + 'requests')
-    def test_fetch_github_data_error(self,
-                                     mock_requests):
+    def test_api_call_get_error(self, mock_requests):
         """
-        Tests the '_fetch_github_data' function where we raise an IOError
+        Tests the 'api_call_get' function where we raise an IOError
         """
         # Set up return values
         get_return = MagicMock()
@@ -644,7 +643,7 @@ class TestUpstreamIssue(unittest.TestCase):
 
         # Call the function
         with self.assertRaises(IOError):
-            u._fetch_github_data(
+            u.api_call_get(
                 url='mock_url',
                 headers='mock_headers'
             )
@@ -653,9 +652,9 @@ class TestUpstreamIssue(unittest.TestCase):
         mock_requests.get.assert_called_with('mock_url', headers='mock_headers')
 
     @mock.patch(PATH + 'requests')
-    def test_fetch_github_data(self, mock_requests):
+    def test_api_call_get(self, mock_requests):
         """
-        Tests the '_fetch_github_data' function where everything goes smoothly!
+        Tests the 'api_call_get' function where everything goes smoothly!
         """
         # Set up return values
         get_return = MagicMock()
@@ -665,7 +664,7 @@ class TestUpstreamIssue(unittest.TestCase):
 
         # Call the function
 
-        response = u._fetch_github_data(
+        response = u.api_call_get(
             url='mock_url',
             headers='mock_headers'
         )

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -32,14 +32,14 @@ class TestUpstreamIssue(unittest.TestCase):
             },
         }
 
-        # Mock Github Comment
+        # Mock GitHub Comment
         self.mock_github_comment = MagicMock()
         self.mock_github_comment.user.name = 'mock_username'
         self.mock_github_comment.body = 'mock_body'
         self.mock_github_comment.id = 'mock_id'
         self.mock_github_comment.created_at = 'mock_created_at'
 
-        # Mock Github Message
+        # Mock GitHub Message
         self.mock_github_message = {
             'msg': {
                 'repository': {
@@ -68,7 +68,7 @@ class TestUpstreamIssue(unittest.TestCase):
         self.mock_github_issue = MagicMock()
         self.mock_github_issue.get_comments.return_value = [self.mock_github_comment]
 
-        # Mock Github Issue Raw
+        # Mock GitHub Issue Raw
         self.mock_github_issue_raw = {
             'comments': ['some comment'],
             'number': '1234',

--- a/tests/test_upstream_pr.py
+++ b/tests/test_upstream_pr.py
@@ -32,14 +32,14 @@ class TestUpstreamPR(unittest.TestCase):
             },
         }
 
-        # Mock Github Comment
+        # Mock GitHub Comment
         self.mock_github_comment = MagicMock()
         self.mock_github_comment.user.name = 'mock_username'
         self.mock_github_comment.body = 'mock_body'
         self.mock_github_comment.id = 'mock_id'
         self.mock_github_comment.created_at = 'mock_created_at'
 
-        # Mock Github Message
+        # Mock GitHub Message
         self.mock_github_message = {
             'msg': {
                 'repository': {
@@ -68,7 +68,7 @@ class TestUpstreamPR(unittest.TestCase):
         self.mock_github_pr = MagicMock()
         self.mock_github_pr.get_issue_comments.return_value = [self.mock_github_comment]
 
-        # Mock Github Issue Raw
+        # Mock GitHub Issue Raw
         self.mock_github_issue_raw = {
             'comments': ['some comment'],
             'number': '1234',


### PR DESCRIPTION
This PR is a series of refactorings and other modest changes to the `upstream_*.py` modules.  The intention is that there be no overall functional change; however, internally, the changes remove a bunch of code duplication, shedding a little over 25% of the previous code.

Each of the first several commits is targeted at removing a particular code duplication.  The commits after that are more code-quality/stylistic changes.

I recommend reviewing it one commit at a time.

A couple of notes on the tests:
- The unit tests, via the mocking, have slightly more insight into the internal structure of the code than I might have wished, so I was not able to use them to validate my changes without also making some changes to them (which kind of undermines their purpose...); however, the test changes were fairly limited (the name of the function being mocked, the change to pass its second parameter by keyword-argument, and the module-path to where the `requests` package is to be patched), so I think the unit tests still did their job.
- At this point, this PR is not expected to be merged as is -- it is mostly intended to record this work for future posterity -- so, there are no new tests for the new subroutines.  Before merging this PR, new tests should be added.