### PR TITLE
Sync priority from GitHub to Jira

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ fedmsg.d/sync2jira.py
 /.tox
 *.pyc
 __pycache__
+.vscode/settings.json

--- a/docs/source/config-file.rst
+++ b/docs/source/config-file.rst
@@ -63,6 +63,22 @@ The config file is made up of multiple parts
 
 .. code-block:: python
 
+    "default_jira_fields": {
+      "storypoints": "customfield_12310243"
+    },
+
+* The keys in the :code:`default_jira_fields` map are used as the values of the github_project_fields
+  list (see below). The keys indicate how the fields in GitHub Project items correspond to
+  fields in Jira issues so that these values can be synced properly. Currently, we support
+  only :code:`storypoints` and :code:`priority`. By default, the value for the priority is sourced
+  from the upstream :code:`priority` field, but providing a :code:`priority` key for
+  :code:`default_jira_fields` will override that. Unfortunately, there is no default available
+  for sourcing story points, so, the :code:`storypoints` key must be provided if projects wish
+  to sync story point values, and, for our corporate Jira instance, the value should be specified
+  as :code:`customfield_12310243`.
+
+.. code-block:: python
+
     'map': {
             'github': {
                 'GITHUB_USERNAME/Demo_project': {'project': 'FACTORY', 'component': 'gitbz',
@@ -124,6 +140,10 @@ The config file is made up of multiple parts
         * If selected this will add a comment to all newly created JIRA issue in the format 'UPSTREAM_PROJECT-#1' where the number indicates the issue ID. This allows users to search for the issue on JIRA via the issue number.
     * :code:`url`
         * This flag will add the upstream url to the bottom of the JIRA ticket
+    * :code:`github_project_number`
+        * Specify the GitHub project number. If specified, story points and priority will be selected from this project, and other projects linked to the issues will be ignored.
+    * :code:`github_project_fields`
+        * Sync GitHub projects fields. e.g, storypoints, priority
 
     .. note::
 
@@ -145,6 +165,33 @@ The config file is made up of multiple parts
 
 * It is strongly encouraged for teams to use the :code:`owner` field. If configured, owners will be alerted if Sync2Jira finds duplicate downstream issues.
   Further the owner will be used as a default in case the program is unable to find a valid assignee.
+
+.. code-block:: python
+
+    'github_project_fields': {
+        'storypoints': {
+          'gh_field': 'Estimate'
+        },
+        'priority': {
+          'gh_field': 'Priority',
+          'options': {
+            'P0': 'Blocker',
+            'P1': 'Critical',
+            'P2': 'Major',
+            'P3': 'Minor',
+            'P4': 'Optional',
+            'P5': 'Trivial'
+          }
+        }
+    }
+
+* Specify the GitHub project field and its mapping to Jira. The currently supportted fields are :code:`storypoints`
+  and :code:`priority`.
+
+* The :code:`gh_field` points to the GitHub field name.
+
+* The :code:`options` key is used to specify a mapping between GitHub field values as Jira field values.
+  This is particularly useful for cases like priority which uses keywords for values.
 
 .. code-block:: python
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -34,11 +34,11 @@ Want to quickly get started working with Sync2Jira? Follow these steps:
         'map': {
             'github': {
                 'GITHUB_USERNAME/Demo_project': {'project': 'FACTORY', 'component': 'gitbz',
-                                                 'updates': [...], 'sync': [..]},
+                                                 'issue_updates': [...], 'sync': [..]},
             },
         },
 
-    .. note:: You can learn more about what can go into the updates list `here <config-file.html>`_
+    .. note:: You can learn more about what can go into the issue_updates list `here <config-file.html>`_
 
 5. Finally you can tweak the config files optional settings to your liking
     .. code-block:: python

--- a/fedmsg.d/sync2jira.py
+++ b/fedmsg.d/sync2jira.py
@@ -53,11 +53,29 @@ config = {
                 'token_auth': 'YOUR_JIRA_ACCESS_TOKEN',
             },
         },
-        'default_github_project_fields': {'storypoints': ('Estimate', 'customfield_12310243')},
+        'default_jira_fields': {
+            'storypoints': 'customfield_12310243',
+            },
         'map': {
             'github': {
                 'GITHUB_USERNAME/Demo_project': {'project': 'FACTORY', 'component': 'gitbz',
-                                                 'updates': [...], 'sync': ['pullrequest', 'issue']},
+                                                'issue_updates': [
+                                                    'comments',
+                                                    'upstream_id',
+                                                    'title',
+                                                    'description',
+                                                    'github_markdown',
+                                                    'upstream_id',
+                                                    'url',
+                                                    {'transition': 'Closed'},
+                                                    {'assignee': {'overwrite': False}},
+                                                    'github_project_fields'],
+                                                'github_project_number': '1',
+                                                'github_project_fields': {'storypoints': {'gh_field': 'Estimate'},
+                                                    'priority': {'gh_field': 'Priority', 'options':
+                                                                 {'P0': 'Blocker', 'P1': 'Critical', 'P2': 'Major',
+                                                                  'P3': 'Minor', 'P4': 'Optional', 'P5': 'Trivial'}}},
+                                                 'sync': ['pullrequest', 'issue']},
             },
         },
         'filters': {

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -93,7 +93,6 @@ class Issue(object):
         if any('fixVersion' in item for item in mapping):
             map_fixVersion(mapping, issue)
 
-        # TODO: Priority is broken
         return cls(
             source=upstream_source,
             title=issue['title'],
@@ -103,7 +102,7 @@ class Issue(object):
             comments=comments,
             tags=issue['labels'],
             fixVersion=[issue['milestone']],
-            priority=None,
+            priority=issue['priority'],
             content=issue['body'] or '',
             reporter=issue['user'],
             assignee=issue['assignees'],

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -28,26 +28,85 @@ import sync2jira.intermediary as i
 
 log = logging.getLogger('sync2jira')
 graphqlurl = 'https://api.github.com/graphql'
-project_items_query = '''
+
+ghquery = '''
     query MyQuery(
-        $orgname: String!, $reponame: String!, $ghfieldname: String!, $issuenumber: Int!
+        $orgname: String!, $reponame: String!, $issuenumber: Int!
     ) {
         repository(owner: $orgname, name: $reponame) {
-            issue(number: $issuenumber) {
-                title
-                body
-                projectItems(first: 1) {
-                    nodes {
-                        fieldValueByName(name: $ghfieldname) {
-                            ... on ProjectV2ItemFieldNumberValue {
-                                number
-                            }
-                        }
-                    }
+          issue(number: $issuenumber) {
+            title
+            body
+            projectItems(first: 3) {
+              nodes {
+                project {
+                  title
+                  number
+                  url
                 }
+                fieldValues(first: 100) {
+                  nodes {
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                      fieldName: field {
+                        ... on ProjectV2FieldCommon {
+                          name
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemFieldTextValue {
+                      text
+                      fieldName: field {
+                        ... on ProjectV2FieldCommon {
+                          name
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemFieldNumberValue {
+                      number
+                      fieldName: field {
+                        ... on ProjectV2FieldCommon {
+                          name
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemFieldDateValue {
+                      date
+                      fieldName: field {
+                        ... on ProjectV2FieldCommon {
+                          name
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemFieldUserValue {
+                      users(first: 10) {
+                        nodes {
+                          login
+                        }
+                      }
+                      fieldName: field {
+                        ... on ProjectV2FieldCommon {
+                          name
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemFieldIterationValue {
+                      title
+                      duration
+                      startDate
+                      fieldName: field {
+                        ... on ProjectV2FieldCommon {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
+          }
         }
-    }
+      }
 '''
 
 
@@ -202,8 +261,10 @@ def github_issues(upstream, config):
     # And get comments if needed
     github_client = Github(config['sync2jira']['github_token'], retry=5)
 
+    orgname, reponame = upstream.rsplit('/', 1)
     # We need to format everything to a standard to we can create an issue object
     final_issues = []
+    project_number = config['sync2jira']['map']['github'][upstream].get('github_project_number')
     for issue in issues:
         # Update comments:
         # If there are no comments just make an empty array
@@ -257,26 +318,41 @@ def github_issues(upstream, config):
         if issue.get('milestone', None):
             issue['milestone'] = issue['milestone']['title']
 
-        if not issue.get('storypoints', None):
-            issue['storypoints'] = ''
-            orgname, reponame = upstream.rsplit('/', 1)
+        issue_updates = config['sync2jira']['map']['github'][upstream].get('issue_updates', {})
+
+        if 'github_project_fields' in issue_updates:
+            issue['storypoints'] = None
+            issue['priority'] = ''
             issuenumber = issue['number']
-            default_github_project_fields = config['sync2jira']['default_github_project_fields']
-            project_github_project_fields = config['sync2jira']['map']['github'].get(upstream, {}).get('github_project_fields', {})
-            github_project_fields = default_github_project_fields | project_github_project_fields
+            github_project_fields = config['sync2jira']['map']['github'][upstream]['github_project_fields']
             variables = {"orgname": orgname, "reponame": reponame, "issuenumber": issuenumber}
-            for fieldname, values in github_project_fields.items():
-                ghfieldname, _ = values
-                variables['ghfieldname'] = ghfieldname
-                response = requests.post(graphqlurl, headers=headers, json={"query": project_items_query, "variables": variables})
-                data = response.json()
-                if fieldname == 'storypoints':
-                    try:
-                        issue[fieldname] = data['data']['repository']['issue']['projectItems']['nodes'][0]['fieldValueByName']['number']
-                    except (TypeError, KeyError) as err:
-                        log.debug("Error fetching %s!r from GitHub %s/%s#%s: %s",
-                                  ghfieldname, orgname, reponame, issuenumber, err)
-                        continue
+            response = requests.post(graphqlurl, headers=headers, json={"query": ghquery, "variables": variables})
+            if response.status_code != 200:
+                log.debug("Error while fetching %s/%s/Issue#%s: %s", orgname, reponame, issuenumber, response.text)
+                continue
+            data = response.json()
+            gh_issue = data['data']['repository']['issue']
+            if not gh_issue:
+                log.debug("Error fetching issue from GitHub: %s. org: %s, repo: %s", response.text, orgname, reponame)
+                continue
+            gh_field_name = ''
+            try:
+                currentProjectNode = _get_current_project_node(upstream, project_number, issuenumber, gh_issue)
+                if not currentProjectNode:
+                    continue
+                for item in currentProjectNode['fieldValues']['nodes']:
+                    if 'fieldName' in item:
+                        gh_field_name = item['fieldName'].get('name')
+                        if 'priority' in github_project_fields\
+                                and gh_field_name == github_project_fields['priority']['gh_field']:
+                            issue['priority'] = item.get('name')
+                        if 'storypoints' in github_project_fields\
+                                and gh_field_name == github_project_fields['storypoints']['gh_field']:
+                            issue['storypoints'] = int(item['number'])
+            except KeyError as err:
+                log.debug("Error fetching %s!r from GitHub %s/%s#%s: %s",
+                          gh_field_name, orgname, reponame, issuenumber, err)
+                continue
 
         final_issues.append(issue)
 
@@ -286,6 +362,32 @@ def github_issues(upstream, config):
     ))
     for issue in final_issues:
         yield issue
+
+
+def _get_current_project_node(upstream, project_number, issue_number, gh_issue):
+    project_items = gh_issue['projectItems']['nodes']
+    # If there are no project items, there is nothing to return.
+    if len(project_items) == 0:
+        log.debug("Issue %s/%s is not associated with any project", upstream, issue_number)
+        return None
+    # If there is exactly one project item, return it if we don't have a configured project.
+    if not project_number and len(project_items) == 1:
+        return project_items[0]
+    # There are multiple projects associated with this issue; if we don't have a configured
+    # project, then we don't know which one to return, so return none.
+    if not project_number:
+        prj = ", ".join([":".join([x['project']['url'], x['project']['title']]) for x in project_items])
+        log.debug(
+            "Project number is not configured, and the issue %s/%s is associated with more than one project: %s",
+            upstream, issue_number, prj)
+        return None
+    # Return the associated project which matches the configured project if we can find it.
+    for item in project_items:
+        if item['project']['number'] == project_number:
+            return item
+
+    log.debug("Issue is not associated with the configured project, but other associations exist.")
+    return None
 
 
 def get_all_github_data(url, headers):

--- a/tests/test_intermediary.py
+++ b/tests/test_intermediary.py
@@ -35,6 +35,7 @@ class TestIntermediary(unittest.TestCase):
             'labels': 'mock_tags',
             'milestone': 'mock_milestone',
             'priority': 'mock_priority',
+            'storypoints': '1.0',
             'body': 'mock_content',
             'user': 'mock_reporter',
             'assignees': 'mock_assignee',
@@ -73,7 +74,6 @@ class TestIntermediary(unittest.TestCase):
         self.assertEqual(response.upstream, 'github')
         self.assertEqual(response.comments, [{'body': 'mock_body', 'name': 'mock_name', 'author': 'mock_author',
                                               'changed': None, 'date_created': 'mock_date', 'id': 'mock_id'}])
-        self.assertEqual(response.priority, None)
         self.assertEqual(response.content, 'mock_content')
         self.assertEqual(response.reporter, 'mock_reporter')
         self.assertEqual(response.assignee, 'mock_assignee')
@@ -94,6 +94,7 @@ class TestIntermediary(unittest.TestCase):
         self.checkResponseFields(response)
 
         self.assertEqual(response.fixVersion, ['mock_milestone'])
+        self.assertEqual(response.priority, 'mock_priority')
         self.assertEqual(response.status, 'Open')
         self.assertEqual(response.downstream, {'mock_downstream': 'mock_key'})
         self.assertEqual(response.storypoints, 'mock_storypoints')
@@ -117,6 +118,7 @@ class TestIntermediary(unittest.TestCase):
 
         self.assertEqual(response.tags, 'mock_tags')
         self.assertEqual(response.fixVersion, ['mock_milestone'])
+        self.assertEqual(response.priority, 'mock_priority')
         self.assertEqual(response.status, 'Closed')
         self.assertEqual(response.downstream, {'mock_downstream': 'mock_key'})
         self.assertEqual(response.storypoints, 'mock_storypoints')
@@ -144,6 +146,7 @@ class TestIntermediary(unittest.TestCase):
 
         self.assertEqual(response.tags, 'mock_tags')
         self.assertEqual(response.fixVersion, ['Test mock_milestone'])
+        self.assertEqual(response.priority, 'mock_priority')
         self.assertEqual(response.status, 'Closed')
         self.assertEqual(response.downstream, {
             'mock_downstream': 'mock_key',


### PR DESCRIPTION
Fixes #198

Example configuration:
```
"default_jira_fields": {
  "storypoints": "customfield_12310243"
},

"map": {
  "github": {
    "developerproductivity/open-connectors": {
      "project": "TEST",
      "sync": [ "issue" ],
      "issue_updates": [ "github_project_fields" ],
      "github_project_number": 1,
      "github_project_fields": {
        "storypoints": {
          "gh_field": "Estimate"
        },
        "priority": {
          "gh_field": "Priority",
          "options": {
            "P0": "Blocker",
            "P1": "Critical",
            "P2": "Major",
            "P3": "Minor",
            "P4": "Optional",
            "P5": "Trivial"
          }
        }
      }
    }
  }
},
```
