### PR TITLE
Fix unit test failures

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -950,6 +950,7 @@ def _update_jira_labels(issue, labels):
     issue.update(data)
     log.info('Updated %s tag(s)' % len(_labels))
 
+
 def _update_github_project_fields(client, existing, issue, github_project_fields):
     """Update a Jira issue with GitHub project item field values
 
@@ -963,9 +964,9 @@ def _update_github_project_fields(client, existing, issue, github_project_fields
         _, jirafieldname = values
         try:
             existing.update({jirafieldname: str(getattr(issue, name))})
-        except JIRAError:
+        except JIRAError as err:
             # Add a comment to indicate there was an issue
-            client.add_comment(existing, f"Error updating GitHub project field")
+            client.add_comment(existing, f"Error updating GitHub project field: {err}")
 
 
 def _update_tags(updates, existing, issue):

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -94,7 +94,7 @@ class Issue(object):
             map_fixVersion(mapping, issue)
 
         # TODO: Priority is broken
-        return Issue(
+        return cls(
             source=upstream_source,
             title=issue['title'],
             url=issue['html_url'],
@@ -272,7 +272,7 @@ def trimString(content):
     Helper function to trim a string to ensure it is not over 50000 char
     Ref: https://github.com/release-engineering/Sync2Jira/issues/123
 
-    :param String commentBody: Comment content
+    :param String content: Comment content
     :rtype: String
     """
     if len(content) > 50000:

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -166,6 +166,7 @@ def handle_github_message(msg, config, pr_filter=True):
 
     return i.Issue.from_github(upstream, msg['msg']['issue'], config)
 
+
 def github_issues(upstream, config):
     """
     Creates a Generator for all GitHub issues in upstream repo.

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -271,7 +271,7 @@ def github_issues(upstream, config):
                         issue[fieldname] = data['data']['repository']['issue']['projectItems']['nodes'][0]['fieldValueByName']['number']
                     except (TypeError, KeyError) as err:
                         log.debug("Error fetching %s!r from GitHub %s/%s#%s: %s",
-                            ghfieldname, orgname, reponame, issuenumber, err)
+                                  ghfieldname, orgname, reponame, issuenumber, err)
                         continue
 
         final_issues.append(issue)

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -257,7 +257,7 @@ def github_issues(upstream, config):
             orgname, reponame = upstream.rsplit('/', 1)
             issuenumber = issue['number']
             default_github_project_fields = config['sync2jira']['default_github_project_fields']
-            project_github_project_fields = config['sync2jira']['map']['github'][upstream]['github_project_fields']
+            project_github_project_fields = config['sync2jira']['map']['github'].get(upstream, {}).get('github_project_fields', {})
             github_project_fields = default_github_project_fields | project_github_project_fields
             variables = {"orgname": orgname, "reponame": reponame, "issuenumber": issuenumber}
             for fieldname, values in github_project_fields.items():

--- a/tests/test_intermediary.py
+++ b/tests/test_intermediary.py
@@ -1,5 +1,5 @@
-import mock
 import unittest
+import unittest.mock as mock
 
 import sync2jira.intermediary as i
 
@@ -126,7 +126,7 @@ class TestIntermediary(unittest.TestCase):
 
     def test_mapping_github(self):
         """
-        This tests the mapping feature from github
+        This tests the mapping feature from GitHub
         """
         # Set up return values
         self.mock_config['sync2jira']['map']['github']['github'] = {
@@ -165,7 +165,7 @@ class TestIntermediary(unittest.TestCase):
     def test_from_github_pr_reopen(self,
                                    mock_matcher):
         """
-        This tests the from GitHub for a PR
+        This tests the message from GitHub for a PR
         """
         # Set up return values
         mock_matcher.return_value = "JIRA-1234"

--- a/tests/test_intermediary.py
+++ b/tests/test_intermediary.py
@@ -65,6 +65,19 @@ class TestIntermediary(unittest.TestCase):
             'number': 1234,
         }
 
+    def checkResponseFields(self, response):
+        self.assertEqual(response.source, 'github')
+        self.assertEqual(response.title, '[github] mock_title')
+        self.assertEqual(response.url, 'mock_url')
+        self.assertEqual(response.upstream, 'github')
+        self.assertEqual(response.comments, [{'body': 'mock_body', 'name': 'mock_name', 'author': 'mock_author',
+                                              'changed': None, 'date_created': 'mock_date', 'id': 'mock_id'}])
+        self.assertEqual(response.priority, None)
+        self.assertEqual(response.content, 'mock_content')
+        self.assertEqual(response.reporter, 'mock_reporter')
+        self.assertEqual(response.assignee, 'mock_assignee')
+        self.assertEqual(response.id, '1234')
+
     def test_from_github_open(self):
         """
         This tests the 'from_github' function under the Issue class where the state is open
@@ -77,20 +90,10 @@ class TestIntermediary(unittest.TestCase):
         )
 
         # Assert that we made the calls correctly
-        self.assertEqual(response.source, 'github')
-        self.assertEqual(response.title, '[github] mock_title')
-        self.assertEqual(response.url, 'mock_url')
-        self.assertEqual(response.upstream, 'github')
-        self.assertEqual(response.comments, [{'body': 'mock_body', 'name': 'mock_name', 'author': 'mock_author',
-                                              'changed': None, 'date_created': 'mock_date', 'id': 'mock_id'}])
-        self.assertEqual(response.tags, 'mock_tags')
+        self.checkResponseFields(response)
+
         self.assertEqual(response.fixVersion, ['mock_milestone'])
-        self.assertEqual(response.priority, None)
-        self.assertEqual(response.content, 'mock_content')
-        self.assertEqual(response.reporter, 'mock_reporter')
-        self.assertEqual(response.assignee, 'mock_assignee')
         self.assertEqual(response.status, 'Open')
-        self.assertEqual(response.id, '1234')
         self.assertEqual(response.downstream, {'mock_downstream': 'mock_key'})
 
     def test_from_github_closed(self):
@@ -108,20 +111,11 @@ class TestIntermediary(unittest.TestCase):
         )
 
         # Assert that we made the calls correctly
-        self.assertEqual(response.source, 'github')
-        self.assertEqual(response.title, '[github] mock_title')
-        self.assertEqual(response.url, 'mock_url')
-        self.assertEqual(response.upstream, 'github')
-        self.assertEqual(response.comments, [{'body': 'mock_body', 'name': 'mock_name', 'author': 'mock_author',
-                                              'changed': None, 'date_created': 'mock_date', 'id': 'mock_id'}])
+        self.checkResponseFields(response)
+
         self.assertEqual(response.tags, 'mock_tags')
         self.assertEqual(response.fixVersion, ['mock_milestone'])
-        self.assertEqual(response.priority, None)
-        self.assertEqual(response.content, 'mock_content')
-        self.assertEqual(response.reporter, 'mock_reporter')
-        self.assertEqual(response.assignee, 'mock_assignee')
         self.assertEqual(response.status, 'Closed')
-        self.assertEqual(response.id, '1234')
         self.assertEqual(response.downstream, {'mock_downstream': 'mock_key'})
 
     def test_mapping_github(self):
@@ -143,20 +137,11 @@ class TestIntermediary(unittest.TestCase):
         )
 
         # Assert that we made the calls correctly
-        self.assertEqual(response.source, 'github')
-        self.assertEqual(response.title, '[github] mock_title')
-        self.assertEqual(response.url, 'mock_url')
-        self.assertEqual(response.upstream, 'github')
-        self.assertEqual(response.comments, [{'body': 'mock_body', 'name': 'mock_name', 'author': 'mock_author',
-                                              'changed': None, 'date_created': 'mock_date', 'id': 'mock_id'}])
+        self.checkResponseFields(response)
+
         self.assertEqual(response.tags, 'mock_tags')
         self.assertEqual(response.fixVersion, ['Test mock_milestone'])
-        self.assertEqual(response.priority, None)
-        self.assertEqual(response.content, 'mock_content')
-        self.assertEqual(response.reporter, 'mock_reporter')
-        self.assertEqual(response.assignee, 'mock_assignee')
         self.assertEqual(response.status, 'Closed')
-        self.assertEqual(response.id, '1234')
         self.assertEqual(response.downstream, {
             'mock_downstream': 'mock_key',
             'mapping': [{'fixVersion': 'Test XXX'}]})
@@ -179,19 +164,10 @@ class TestIntermediary(unittest.TestCase):
         )
 
         # Assert that we made the calls correctly
-        self.assertEqual(response.source, 'github')
-        self.assertEqual(response.title, '[github] mock_title')
-        self.assertEqual(response.url, 'mock_url')
-        self.assertEqual(response.upstream, 'github')
-        self.assertEqual(response.comments, [{'body': 'mock_body', 'name': 'mock_name', 'author': 'mock_author',
-                                              'changed': None, 'date_created': 'mock_date', 'id': 'mock_id'}])
-        self.assertEqual(response.priority, None)
-        self.assertEqual(response.content, 'mock_content')
-        self.assertEqual(response.reporter, 'mock_reporter')
-        self.assertEqual(response.assignee, 'mock_assignee')
-        self.assertEqual(response.status, None)
-        self.assertEqual(response.id, '1234')
+        self.checkResponseFields(response)
+
         self.assertEqual(response.suffix, 'reopened')
+        self.assertEqual(response.status, None)
         self.assertEqual(response.downstream, {'mock_downstream': 'mock_key'})
         self.assertEqual(response.jira_key, "JIRA-1234")
         self.mock_github_pr['comments'][0]['changed'] = None

--- a/tests/test_intermediary.py
+++ b/tests/test_intermediary.py
@@ -41,6 +41,7 @@ class TestIntermediary(unittest.TestCase):
             'state': 'open',
             'date_created': 'mock_date',
             'number': '1',
+            'storypoints': 'mock_storypoints',
         }
 
         self.mock_github_pr = {
@@ -95,6 +96,7 @@ class TestIntermediary(unittest.TestCase):
         self.assertEqual(response.fixVersion, ['mock_milestone'])
         self.assertEqual(response.status, 'Open')
         self.assertEqual(response.downstream, {'mock_downstream': 'mock_key'})
+        self.assertEqual(response.storypoints, 'mock_storypoints')
 
     def test_from_github_closed(self):
         """
@@ -117,6 +119,7 @@ class TestIntermediary(unittest.TestCase):
         self.assertEqual(response.fixVersion, ['mock_milestone'])
         self.assertEqual(response.status, 'Closed')
         self.assertEqual(response.downstream, {'mock_downstream': 'mock_key'})
+        self.assertEqual(response.storypoints, 'mock_storypoints')
 
     def test_mapping_github(self):
         """
@@ -145,6 +148,7 @@ class TestIntermediary(unittest.TestCase):
         self.assertEqual(response.downstream, {
             'mock_downstream': 'mock_key',
             'mapping': [{'fixVersion': 'Test XXX'}]})
+        self.assertEqual(response.storypoints, 'mock_storypoints')
 
     @mock.patch(PATH + 'matcher')
     def test_from_github_pr_reopen(self,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -106,7 +106,7 @@ class TestMain(unittest.TestCase):
 
         # Assert everything was called correctly
         mock_load_config.assert_called_once()
-        mock_u.github_issues.assert_not_called()
+        mock_u.github_issues.assert_called_once()
         mock_d.close_duplicates.assert_called_with('mock_issue', self.mock_config)
 
     @mock.patch(PATH + 'load_config')
@@ -268,7 +268,7 @@ class TestMain(unittest.TestCase):
 
         # Assert everything was called correctly
         mock_u.github_issues.assert_called_with('key_github', self.mock_config)
-        mock_d.sync_with_jira.assert_any_call('mock_issue_github', self.mock_config)
+        mock_d.sync_with_jira.assert_not_called()
         mock_sleep.assert_called_with(3600)
         mock_report_failure.assert_not_called()
 
@@ -294,7 +294,7 @@ class TestMain(unittest.TestCase):
 
         # Assert everything was called correctly
         mock_u.github_issues.assert_called_with('key_github', self.mock_config)
-        mock_d.sync_with_jira.assert_any_call('mock_issue_github', self.mock_config)
+        mock_d.sync_with_jira.assert_not_called()
         mock_sleep.assert_not_called()
         mock_report_failure.assert_called_with(self.mock_config)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,7 +56,7 @@ class TestMain(unittest.TestCase):
 
     def test_config_validate_mispelled_mappings(self):
         loader = lambda: {'sync2jira': {'map': {'githob': {}}}, 'jira': {}}
-        self._check_for_exception(loader, 'Specified handlers: "pageur", must')
+        self._check_for_exception(loader, 'Specified handlers: "githob", must')
 
     def test_config_validate_missing_jira(self):
         loader = lambda: {'sync2jira': {'map': {'github': {}}}}

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -15,6 +15,9 @@ class TestUpstreamIssue(unittest.TestCase):
     def setUp(self):
         self.mock_config = {
             'sync2jira': {
+                'default_github_project_fields': {
+                    'storypoints': ('Estimate', 'customfield_12310243')
+                },
                 'map': {
                     'github': {
                         'org/repo': {'sync': ['issue']},
@@ -130,10 +133,22 @@ class TestUpstreamIssue(unittest.TestCase):
         self.mock_github_client.get_user.assert_any_call('mock_assignee_login')
         mock_issue_from_github.assert_called_with(
             'org/repo',
-            {'labels': ['some_label'], 'number': '1234', 'comments': [
-                {'body': 'mock_body', 'name': unittest.mock.ANY, 'author': 'mock_username', 'changed': None,
-                 'date_created': 'mock_created_at', 'id': 'mock_id'}], 'assignees': [{'fullname': 'mock_name'}],
-             'user': {'login': 'mock_login', 'fullname': 'mock_name'}, 'milestone': 'mock_milestone'},
+            {
+                'labels': ['some_label'],
+                'number': '1234',
+                'comments': [
+                    {
+                        'body': 'mock_body',
+                        'name': unittest.mock.ANY,
+                        'author': 'mock_username',
+                        'changed': None,
+                        'date_created': 'mock_created_at',
+                        'id': 'mock_id'}
+                ],
+                'assignees': [{'fullname': 'mock_name'}],
+                'user': {'login': 'mock_login', 'fullname': 'mock_name'},
+                'milestone': 'mock_milestone',
+                'storypoints': ''},
             self.mock_config
         )
         self.mock_github_client.get_repo.assert_called_with('org/repo')
@@ -180,8 +195,16 @@ class TestUpstreamIssue(unittest.TestCase):
         self.mock_github_client.get_user.assert_any_call('mock_assignee_login')
         mock_issue_from_github.assert_called_with(
             'org/repo',
-            {'labels': ['some_label'], 'number': '1234', 'comments': [], 'assignees': [{'fullname': 'mock_name'}],
-             'user': {'login': 'mock_login', 'fullname': 'mock_name'}, 'milestone': 'mock_milestone'},
+            {
+                'labels': ['some_label'],
+                'number': '1234',
+                'comments': [],
+                'assignees': [{'fullname': 'mock_name'}],
+                'user': {
+                    'login': 'mock_login',
+                    'fullname': 'mock_name'},
+                'milestone': 'mock_milestone',
+                'storypoints': ''},
             self.mock_config
         )
         self.assertEqual(response[0], 'Successful Call!')


### PR DESCRIPTION
Unfortunately, while the CI currently runs the unit tests via GitHub Actions, the results aren't reported to PRs, and failures don't block merges.  As such, a recent merge broke the unit tests, and subsequent merges have introduced additional failures.

This PR comprises remediations for the existing unit tests and brings `main` back into passing status.

The branch consists of a number small, topical commits for your reviewing pleasure.  Please pay especial attention to the last commit which contains a series of changes reversing specific assertions.  Looking at the code, I don't understand how these tests ever passed...so, if someone could please explain that and/or point out why my change should not be included, I would greatly appreciate it.

This change also includes a modest refactoring of the unit tests for the intermediary module which DRYs out the code a bit.