### PR TITLE
Update workflow checkout action and triggers

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,14 +3,20 @@ name: Run Tox
 
 # yamllint disable rule:truthy
 on:
-  - push
+  push:
+    branches:
+      - main
+      - legacy
+    tags:
+      - v*
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Run Tox tests
         id: test


### PR DESCRIPTION
The current GitHub Action workflow for this repo is triggered only on `push`es to the upstream repo.  This means that it is not run, for instance, for pull requests from forks of this repo.  And, that means that the results of the run cannot be used as a check on PRs.

This PR reworks the workflow triggers:
- The workflow will now be triggered for pull requests.  Once this is in place, we should get feedback in the PRs and be able to enable a rule for our favorite branches which blocks merges that do not pass the tests.
- The workflow will now be triggered only for pushes to the `main` and `legacy` branches.  This ensures that the results of merges still test properly.  (Note that we can add additional branches here and/or use wildcards to select branches, but having both `push` and `pull_request` triggers results in redundant workflow executions if someone posts a PR from an upstream branch, which is why I've put this restriction in place -- let me know if you want this altered.)
- The workflow will also trigger if we ever create any releases or other tags beginning with the letter `v`.  This ensures that the releases still test properly.  This is limited to "v"-tags, so that we are free to use labels without otherwise interacting with the CI.

This PR also brings the `checkout` action up to the latest version.