### PR TITLE
Handle case where storypoints is not defined

### DIFF
--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -109,7 +109,7 @@ class Issue(object):
             assignee=issue['assignees'],
             status=issue['state'],
             id=issue['id'],
-            storypoints=issue['storypoints'],
+            storypoints=issue.get('storypoints', ''),
             upstream_id=issue['number']
         )
 


### PR DESCRIPTION
I see dozens of tracebacks over the last few days with a `KeyError` here.