### PR TITLE
Storypoint touchup

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -578,12 +578,10 @@ def _get_preferred_issue_types(config, issue):
     #     'enhancement': 'Story'
     #   }
     type_list = []
-    log.debug(config)
 
     map = config['sync2jira'].get('map', {})
     conf = map.get('github', {}).get(issue.upstream, {})
 
-    log.debug(conf)
     # we consider the issue_types mapping if it exists. If it does, exclude all other logic.
     if 'issue_types' in conf:
         for tag, issue_type in conf['issue_types'].items():
@@ -616,11 +614,6 @@ def _create_jira_issue(client, issue, config):
     :returns: Returns JIRA issue that was created
     :rtype: jira.resources.Issue
     """
-    log.info("Creating %r issue for %r", issue.downstream, issue)
-    if config['sync2jira']['testing']:
-        log.info("Testing flag is true.  Skipping actual creation.")
-        return
-
     custom_fields = issue.downstream.get('custom_fields', {})
     preferred_types = _get_preferred_issue_types(config, issue)
     description = _build_description(issue)
@@ -646,7 +639,11 @@ def _create_jira_issue(client, issue, config):
     if 'labels' in issue.downstream.keys():
         kwargs['labels'] = issue.downstream['labels']
 
-    log.info("Creating issue.")
+    log.info("Creating issue for %r:  %r", issue, kwargs)
+    if config['sync2jira']['testing']:
+        log.info("Testing flag is true.  Skipping actual creation.")
+        return
+
     downstream = client.create_issue(**kwargs)
 
     # Add Epic link, QA, EXD-Service field if present

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -689,7 +689,7 @@ class TestUpstreamIssue(unittest.TestCase):
                     'org/repo', project, 'mock_number', gh_issue)
                 expected_result = (
                     None if node_count == 0 else
-                    nodes[0] if node_count == 1 else
+                    (nodes[0] if project is None else None) if node_count == 1 else
                     nodes[1] if project == 2 else
                     None)
                 self.assertEqual(result, expected_result)

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -670,47 +670,26 @@ class TestUpstreamIssue(unittest.TestCase):
             headers='mock_headers'
         )
 
-    def test_get_current_project_node_no_projects(self):
-        """
-        This function tests '_get_current_project_node' where there are no project nodes
-        """
-        gh_issue = {'projectItems': {'nodes': []}}
-        result = u._get_current_project_node('org/repo', 1, 'mock_number', gh_issue)
-        self.assertIsNone(result)
+    def test_get_current_project_node(self):
+        """This function tests '_get_current_project_node' in a matrix of cases.
 
-    def test_get_current_project_node_single_project_no_project_number(self):
+        It tests issues with zero, one, and two associated projects when the
+        call is made with no configured project, with a project which matches
+        none of the associated projects, and with a project which matches one.
         """
-        This function tests '_get_current_project_node' where there is a single project
-        node and no project number
-        """
-        gh_issue = {'projectItems': {'nodes': [{'project': {'number': 1}}]}}
-        result = u._get_current_project_node('org/repo', None, 'mock_number', gh_issue)
-        self.assertEqual(result, {'project': {'number': 1}})
-
-    def test_get_current_project_node_multiple_projects_no_project_number(self):
-        """
-        This function tests '_get_current_project_node' where there are multiple project nodes
-        and no project number
-        """
-        gh_issue = {'projectItems': {'nodes': [
+        nodes = [
             {'project': {'number': 1, 'url': 'url1', 'title': 'title1'}},
-            {'project': {'number': 2, 'url': 'url2', 'title': 'title2'}}]}}
-        result = u._get_current_project_node('org/repo', None, 'mock_number', gh_issue)
-        self.assertIsNone(result)
+            {'project': {'number': 2, 'url': 'url2', 'title': 'title2'}}]
+        projects = [None, 2, 5]
 
-    def test_get_current_project_node_project_not_associated(self):
-        """
-        This function tests '_get_current_project_node' where the issue is not associated with
-        the configured project
-        """
-        gh_issue = {'projectItems': {'nodes': [{'project': {'number': 1}}]}}
-        result = u._get_current_project_node('org/repo', 2, 'mock_number', gh_issue)
-        self.assertIsNone(result)
-
-    def test_get_current_project_node_success(self):
-        """
-        This function tests '_get_current_project_node' where everything goes smoothly
-        """
-        gh_issue = {'projectItems': {'nodes': [{'project': {'number': 1}}, {'project': {'number': 2}}]}}
-        result = u._get_current_project_node('org/repo', 2, 'mock_number', gh_issue)
-        self.assertEqual(result, {'project': {'number': 2}})
+        for project in projects:
+            for node_count in range(len(nodes)+1):
+                gh_issue = {'projectItems': {'nodes': nodes[:node_count]}}
+                result = u._get_current_project_node(
+                    'org/repo', project, 'mock_number', gh_issue)
+                expected_result = (
+                    None if node_count == 0 else
+                    nodes[0] if node_count == 1 else
+                    nodes[1] if project == 2 else
+                    None)
+                self.assertEqual(result, expected_result)


### PR DESCRIPTION
Matt and I were playing with a configuration for sync'ing priorities and story points, and it didn't seem to be working, so I dove into the code and smoothed a few rough edges.

The first commit in this branch is some small edits to the downstream-issue code to tweak the logging.  I've removed two log messages which were just repeatedly logging the configuration.  I don't think they were doing anything other than adding to the noise.  I also moved the log message which reports the creation of the downstream issue to a point where it can actually report what it is creating.  Previously, it, too, was dumping a bunch of unilluminating configuration information, and now it reports the contents of the creation request.  @ralphbean, let me know if you want any of this stuff restored.

The other commit contains a bunch of stuff:
- I added a test to filter out PR "issues" before we try to pull project information from them, because the GitHub query fails, because they are not specifically _issues_.  Please let me know if this should actually be triggering a `continue` statement to skip the whole issue, rather than skipping just the project fields.
- I tweaked a bunch of the log messages.  In some cases, I added context.  In others, I just made them more uniform.
- I did some rework of the code which locates the project node for an issue.
  - Previously, if we were unable to find a suitable project, we skipped syncing the entire issue.  Matt and I concluded that this is undesirable -- the proposed code now sync's the issue regardless of whether there is an associated project.  If there is no associated project, it doesn't try to sync the priority or storypoint fields. 
  - I reworked the handling when there is no configured project:  it should work as it did before, but the no-configured-project now has a single, combined flow.
  - These changes represent a change in policy/behavior and so they broke the unit tests.  So, I replaced the five previous unit tests with a single, matrix-based test which tests nine scenarios and matches the new behavior.
- And, I did a little code-smithing in a couple of places.
