### PR TITLE
Workaround for FedMsg storypoint (str) values

### DIFF
--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1688,6 +1688,19 @@ class TestDownstreamIssue(unittest.TestCase):
                                   github_project_fields, self.mock_config)
         self.mock_downstream.update.assert_called_with({'customfield_12310243': 2})
 
+    @mock.patch('jira.client.JIRA')
+    def test_update_github_project_fields_storypoints_bad(self, mock_client):
+        """This function tests `_update_github_project_fields` with
+        a bad (non-numeric) story points value.
+        """
+        github_project_fields = {"storypoints": {"gh_field": "Estimate"}}
+        for bad_sp in [None, '', 'bad_value']:
+            self.mock_issue.storypoints = bad_sp
+            d._update_github_project_fields(
+                mock_client, self.mock_downstream, self.mock_issue,
+                github_project_fields, self.mock_config)
+            self.mock_downstream.update.assert_not_called()
+            mock_client.add_comment.assert_not_called()
 
     @mock.patch('jira.client.JIRA')
     def test_update_github_project_fields_priority(self, mock_client):
@@ -1709,3 +1722,27 @@ class TestDownstreamIssue(unittest.TestCase):
         d._update_github_project_fields(mock_client, self.mock_downstream, self.mock_issue,
                                   github_project_fields, self.mock_config)
         self.mock_downstream.update.assert_called_with({'priority': {'name': 'Critical'}})
+
+    @mock.patch('jira.client.JIRA')
+    def test_update_github_project_fields_priority_bad(self, mock_client):
+        """This function tests `_update_github_project_fields` with
+        a bad priority value.
+        """
+        github_project_fields = {
+            "priority": {
+                "gh_field": "Priority",
+                "options": {
+                    "P0": "Blocker",
+                    "P1": "Critical",
+                    "P2": "Major",
+                    "P3": "Minor",
+                    "P4": "Optional",
+                    "P5": "Trivial"
+                }}}
+        for bad_pv in [None, '', 'bad_value']:
+            self.mock_issue.priority = bad_pv
+            d._update_github_project_fields(
+                mock_client, self.mock_downstream, self.mock_issue,
+                github_project_fields, self.mock_config)
+            self.mock_downstream.update.assert_not_called()
+            mock_client.add_comment.assert_not_called()


### PR DESCRIPTION
Attempting to actually use the storypoint sync'ing [fails](https://issues.redhat.com/browse/IDEEXT-366?focusedId=26153477&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26153477) because the storypoint value must be a number, and we're (apparently) presenting it as a string.

The problem arises from the fact that, until we merge #207, there is substantial duplication in the source, and the change in #216 to introduce support for storypoint sync'ing covered only the repo-initialization path and not the FedMsg update path.

This PR introduces a stop-gap into the downstream issue code which attempts to force the story point value to be an `int`, and, if it fails, simply skips the update.  Once the upstream/intermediate code is corrected to supply a numeric value (or no value), this conversion can be removed.

This PR also tweaks the downstream code for setting Priority values and improves the logging of errors, and it adds some unit tests to detect these problems.

CC: @baijum 