### PR TITLE
Refactor:  encapsulate REST API GET calls

### DIFF
--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -417,9 +417,9 @@ def get_all_github_data(url, headers):
     """ Pagination utility.  Obnoxious. """
     link = dict(next=url)
     while 'next' in link:
-        response = _fetch_github_data(link['next'], headers)
+        response = api_call_get(link['next'], headers=headers)
         for issue in response.json():
-            comments = _fetch_github_data(issue['comments_url'], headers)
+            comments = api_call_get(issue['comments_url'], headers=headers)
             issue['comments'] = comments.json()
             yield issue
         link = _github_link_field_to_dict(response.headers.get('link', None))
@@ -441,12 +441,11 @@ def _github_link_field_to_dict(field):
     ])
 
 
-def _fetch_github_data(url, headers):
-    """
-        Helper function to gather GitHub data
-    """
-    response = requests.get(url, headers=headers)
+def api_call_get(url, **kwargs):
+    """Helper function to encapsulate a REST API GET call"""
+    response = requests.get(url, **kwargs)
     if not bool(response):
+        # noinspection PyBroadException
         try:
             reason = response.json()
         except Exception:

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -597,11 +597,11 @@ class TestUpstreamIssue(unittest.TestCase):
         self.mock_github_issue.get_comments.assert_any_call()
         self.mock_github_client.get_user.assert_called_with('mock_login')
 
-    @mock.patch(PATH + '_fetch_github_data')
+    @mock.patch(PATH + 'api_call_get')
     @mock.patch(PATH + '_github_link_field_to_dict')
     def test_get_all_github_data(self,
                                  mock_github_link_field_to_dict,
-                                 mock_fetch_github_data):
+                                 mock_api_call_get):
         """
         This tests the '_get_all_github_data' function
         """
@@ -609,7 +609,7 @@ class TestUpstreamIssue(unittest.TestCase):
         get_return = MagicMock()
         get_return.json.return_value = [{'comments_url': 'mock_comments_url'}]
         get_return.headers = {'link': 'mock_link'}
-        mock_fetch_github_data.return_value = get_return
+        mock_api_call_get.return_value = get_return
 
         # Call the function
         response = list(u.get_all_github_data(
@@ -618,16 +618,15 @@ class TestUpstreamIssue(unittest.TestCase):
         ))
 
         # Assert everything was called correctly
-        mock_fetch_github_data.assert_any_call('mock_url', 'mock_headers')
-        mock_fetch_github_data.assert_any_call('mock_comments_url', 'mock_headers')
+        mock_api_call_get.assert_any_call('mock_url', headers='mock_headers')
+        mock_api_call_get.assert_any_call('mock_comments_url', headers='mock_headers')
         mock_github_link_field_to_dict.assert_called_with('mock_link')
         self.assertEqual('mock_comments_url', response[0]['comments_url'])
 
     @mock.patch(PATH + 'requests')
-    def test_fetch_github_data_error(self,
-                                     mock_requests):
+    def test_api_call_get_error(self, mock_requests):
         """
-        Tests the '_fetch_github_data' function where we raise an IOError
+        Tests the 'api_call_get' function where we raise an IOError
         """
         # Set up return values
         get_return = MagicMock()
@@ -644,7 +643,7 @@ class TestUpstreamIssue(unittest.TestCase):
 
         # Call the function
         with self.assertRaises(IOError):
-            u._fetch_github_data(
+            u.api_call_get(
                 url='mock_url',
                 headers='mock_headers'
             )
@@ -653,9 +652,9 @@ class TestUpstreamIssue(unittest.TestCase):
         mock_requests.get.assert_called_with('mock_url', headers='mock_headers')
 
     @mock.patch(PATH + 'requests')
-    def test_fetch_github_data(self, mock_requests):
+    def test_api_call_get(self, mock_requests):
         """
-        Tests the '_fetch_github_data' function where everything goes smoothly!
+        Tests the 'api_call_get' function where everything goes smoothly!
         """
         # Set up return values
         get_return = MagicMock()
@@ -665,7 +664,7 @@ class TestUpstreamIssue(unittest.TestCase):
 
         # Call the function
 
-        response = u._fetch_github_data(
+        response = u.api_call_get(
             url='mock_url',
             headers='mock_headers'
         )


### PR DESCRIPTION
This PR is the first of the series of refactorings originally set out in #207 which endeavors to replace duplicated code in Sync2Jira with common subroutines.

This change renames and generalizes a utility routine used to make a `GET` call to a REST API (to GitHub, in particular) so that it can be used in other places in the code, as well (coming in a future PR).  And, it updates the unit tests for the new function name and change in function signature.