### PR TITLE
Various cleanups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+arrow
 jira
 requests
 requests_kerberos

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -378,8 +378,8 @@ def _get_current_project_node(upstream, project_number, issue_number, gh_issue):
 
 
 def get_all_github_data(url, headers):
-    """ Pagination utility.  Obnoxious. """
-    link = dict(next=url)
+    """A generator which returns each response from a paginated GitHub API call"""
+    link = {'next': url}
     while 'next' in link:
         response = api_call_get(link['next'], headers=headers)
         for issue in response.json():
@@ -390,19 +390,16 @@ def get_all_github_data(url, headers):
 
 
 def _github_link_field_to_dict(field):
-    """
-        Utility for ripping apart github's Link header field.
-        It's kind of ugly.
-    """
+    """Utility for ripping apart GitHub's Link header field."""
 
     if not field:
-        return dict()
-    return dict([
+        return {}
+    return dict(
         (
             part.split('; ')[1][5:-1],
-            part.split('; ')[0][1:-1],
+            part.split('; ')[0][1:-1]
         ) for part in field.split(', ')
-    ])
+    )
 
 
 def api_call_get(url, **kwargs):

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -151,7 +151,7 @@ def handle_github_message(msg, config, pr_filter=True):
                 return None
         elif key == 'milestone':
             # special handling for milestone: use the number
-            milestone = issue.get(key) or {}
+            milestone = issue.get(key, {})
             actual = milestone.get('number')
             if expected != actual:
                 log.debug("Milestone %s not set on issue: %s", expected, upstream)
@@ -164,10 +164,9 @@ def handle_github_message(msg, config, pr_filter=True):
                           key, actual, expected, upstream)
                 return None
 
-    if pr_filter and 'pull_request' in issue:
-        if not issue.get('closed_at'):
-            log.debug("%r is a pull request.  Ignoring.", issue.get('html_url'))
-            return None
+    if pr_filter and 'pull_request' in issue and 'closed_at' not in issue:
+        log.debug("%r is a pull request.  Ignoring.", issue.get('html_url', '<missing URL>'))
+        return None
 
     github_client = Github(config['sync2jira']['github_token'], retry=5)
     reformat_github_issue(issue, upstream, github_client)
@@ -387,7 +386,7 @@ def get_all_github_data(url, headers):
             comments = api_call_get(issue['comments_url'], headers=headers)
             issue['comments'] = comments.json()
             yield issue
-        link = _github_link_field_to_dict(response.headers.get('link', None))
+        link = _github_link_field_to_dict(response.headers.get('link'))
 
 
 def _github_link_field_to_dict(field):

--- a/sync2jira/upstream_pr.py
+++ b/sync2jira/upstream_pr.py
@@ -19,12 +19,6 @@
 
 import logging
 
-try:
-    string_type = str
-except ImportError:
-    import types
-    string_type = types.StringTypes
-
 from github import Github
 
 import sync2jira.intermediary as i

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -32,14 +32,14 @@ class TestUpstreamIssue(unittest.TestCase):
             },
         }
 
-        # Mock Github Comment
+        # Mock GitHub Comment
         self.mock_github_comment = MagicMock()
         self.mock_github_comment.user.name = 'mock_username'
         self.mock_github_comment.body = 'mock_body'
         self.mock_github_comment.id = 'mock_id'
         self.mock_github_comment.created_at = 'mock_created_at'
 
-        # Mock Github Message
+        # Mock GitHub Message
         self.mock_github_message = {
             'msg': {
                 'repository': {
@@ -68,7 +68,7 @@ class TestUpstreamIssue(unittest.TestCase):
         self.mock_github_issue = MagicMock()
         self.mock_github_issue.get_comments.return_value = [self.mock_github_comment]
 
-        # Mock Github Issue Raw
+        # Mock GitHub Issue Raw
         self.mock_github_issue_raw = {
             'comments': ['some comment'],
             'number': '1234',

--- a/tests/test_upstream_pr.py
+++ b/tests/test_upstream_pr.py
@@ -32,14 +32,14 @@ class TestUpstreamPR(unittest.TestCase):
             },
         }
 
-        # Mock Github Comment
+        # Mock GitHub Comment
         self.mock_github_comment = MagicMock()
         self.mock_github_comment.user.name = 'mock_username'
         self.mock_github_comment.body = 'mock_body'
         self.mock_github_comment.id = 'mock_id'
         self.mock_github_comment.created_at = 'mock_created_at'
 
-        # Mock Github Message
+        # Mock GitHub Message
         self.mock_github_message = {
             'msg': {
                 'repository': {
@@ -68,7 +68,7 @@ class TestUpstreamPR(unittest.TestCase):
         self.mock_github_pr = MagicMock()
         self.mock_github_pr.get_issue_comments.return_value = [self.mock_github_comment]
 
-        # Mock Github Issue Raw
+        # Mock GitHub Issue Raw
         self.mock_github_issue_raw = {
             'comments': ['some comment'],
             'number': '1234',


### PR DESCRIPTION
This PR is the next in the series of refactorings originally set out in https://github.com/release-engineering/Sync2Jira/pull/207 which endeavors to replace duplicated code in Sync2Jira with common subroutines; this is the follow-on to https://github.com/release-engineering/Sync2Jira/pull/252.

This PR is a bunch of small bits of cleanup, organized into four commits which can be individually reviewed if that makes it easier.
- Add an missing entry to `requirements.txt` (I assume we just got "lucky" that the build worked without it.)
- Extract common subexpressions
- Remove unnecessary list instantiations
- Remove explicit specifications of `None` as the default value parameter to `dict.get()` calls, since it is redundant
- Replace uses of `get()` in contexts where the key is known to exist
- Fix the spelling of "GitHub" in some comments
- Remove a vestigial Python-2-ism
- Other smaller tweaks