### PR TITLE
Use iterators instead of instantiating lists/tuples

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -261,7 +261,7 @@ def alert_user_of_duplicate_issues(issue, final_result, results_of_query,
     admins = []
     admin_template = []
     for admin in config['sync2jira']['admins']:
-        admin_username = [name for name in admin][0]
+        admin_username = next(name for name in admin).strip()
         ret = client.search_users(admin_username)
         if len(ret) > 1:
             log.warning('Found multiple users for admin %s', admin_username)
@@ -810,7 +810,7 @@ def _update_transition(client, existing, issue):
     # downstream JIRA ticket
 
     # First get the closed status from the config file
-    closed_status = list(filter(lambda d: "transition" in d, issue.downstream.get('issue_updates', {})))[0]['transition']
+    closed_status = next(filter(lambda d: "transition" in d, issue.downstream.get('issue_updates', {})))['transition']
     if closed_status is not True and issue.status == 'Closed' \
             and existing.fields.status.name.upper() != closed_status.upper():
         # Now we need to update the status of the JIRA issue
@@ -871,7 +871,7 @@ def _update_fixVersion(updates, existing, issue, client):
     """
     fix_version = []
     # If we are not supposed to overwrite JIRA content
-    if not bool(list(filter(lambda d: "fixVersion" in d, updates))[0]['fixVersion']['overwrite']):
+    if not bool(next(filter(lambda d: "fixVersion" in d, updates))['fixVersion']['overwrite']):
         # We need to make sure we're not deleting any fixVersions on JIRA
         # Get all fixVersions for the issue
         for version in existing.fields.fixVersions:
@@ -918,7 +918,7 @@ def _update_assignee(client, existing, issue, updates):
         :returns: Nothing
     """
     # First check if overwrite is set to True
-    overwrite = bool(list(filter(lambda d: "assignee" in d, updates))[0]['assignee']['overwrite'])
+    overwrite = bool(next(filter(lambda d: "assignee" in d, updates))['assignee']['overwrite'])
 
     # First check if the issue is already assigned to the same person
     update = False
@@ -1049,7 +1049,7 @@ def _update_tags(updates, existing, issue):
     updated_labels = issue.tags
 
     # Ensure no duplicates if overwrite is set to false
-    if not bool(list(filter(lambda d: "tags" in d, updates))[0]['tags']['overwrite']):
+    if not bool(next(filter(lambda d: "tags" in d, updates))['tags']['overwrite']):
         updated_labels = _label_matching(updated_labels, existing.fields.labels)
 
     # Ensure that the tags are all valid

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -146,7 +146,7 @@ def update_transition(client, existing, pr, transition_type):
     :returns: Nothing
     """
     # Get our closed status
-    closed_status = list(filter(lambda d: transition_type in d, pr.downstream.get('pr_updates', {})))[0][transition_type]
+    closed_status = next(filter(lambda d: transition_type in d, pr.downstream.get('pr_updates', {})))[transition_type]
 
     # Update the state
     d_issue.change_status(client, existing, closed_status, pr)

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -229,7 +229,7 @@ def map_fixVersion(mapping, issue):
     :param Dict issue: Upstream issue object
     """
     # Get our fixVersion mapping
-    fixVersion_map = list(filter(lambda d: "fixVersion" in d, mapping))[0]['fixVersion']
+    fixVersion_map = next(filter(lambda d: "fixVersion" in d, mapping))['fixVersion']
 
     # Now update the fixVersion
     if issue['milestone']:


### PR DESCRIPTION
This PR is the next in the series of refactorings originally set out in https://github.com/release-engineering/Sync2Jira/pull/207 which endeavors to improve code quality in Sync2Jira; this is the follow-on to https://github.com/release-engineering/Sync2Jira/pull/254.

This change replaces instances in the code where we instantiate a list from a generator only to access the first element.  Instead, we use the `next()` function to produce only the first element and avoid the list instantiation and the overhead of repeatedly invoking the generator.