### PR TITLE
Simplify PR #222

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -17,18 +17,17 @@
 #
 # Authors:  Ralph Bean <rbean@redhat.com>
 
-# Build-In Modules
-import operator
-import logging
-import re
+# Python Standard Library Modules
+from datetime import datetime, timezone
 import difflib
+import logging
+import operator
+import re
 
 # 3rd Party Modules
 import arrow
-import jira.client
 from jira import JIRAError
-from datetime import datetime
-from zoneinfo import ZoneInfo
+import jira.client
 import jinja2
 import pypandoc
 
@@ -38,8 +37,7 @@ from sync2jira.mailer import send_mail
 
 # The date the service was upgraded
 # This is used to ensure legacy comments are not touched
-UTC = ZoneInfo(key='UTC')
-UPDATE_DATE = datetime(2019, 7, 9, 18, 18, 36, 480291, UTC)
+UPDATE_DATE = datetime(2019, 7, 9, 18, 18, 36, 480291, tzinfo=timezone.utc)
 
 log = logging.getLogger('sync2jira')
 

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1,8 +1,7 @@
 import unittest
 import unittest.mock as mock
 from unittest.mock import MagicMock
-from datetime import datetime
-from zoneinfo import ZoneInfo
+from datetime import datetime, timezone
 
 import sync2jira.downstream_issue as d
 from sync2jira.intermediary import Issue
@@ -11,8 +10,6 @@ import jira.client
 from jira import JIRAError
 
 PATH = 'sync2jira.downstream_issue.'
-
-UTC = ZoneInfo(key='UTC')
 
 
 class TestDownstreamIssue(unittest.TestCase):
@@ -1494,7 +1491,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_jira_comment.raw = {'body': 'mock_legacy_comment_body'}
         mock_comment = {
             'id': '12345',
-            'date_created': datetime(2019, 8, 8, 0, 0, 0, 0, UTC)
+            'date_created': datetime(2019, 8, 8, tzinfo=timezone.utc)
         }
 
         # Call the function
@@ -1520,7 +1517,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_jira_comment.raw = {'body': '12345'}
         mock_comment = {
             'id': '12345',
-            'date_created': datetime(2019, 8, 8, 0, 0, 0, 0, UTC)
+            'date_created': datetime(2019, 8, 8, tzinfo=timezone.utc)
         }
 
         # Call the function
@@ -1546,7 +1543,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_jira_comment.raw = {'body': 'old_comment'}
         mock_comment = {
             'id': '12345',
-            'date_created': datetime(2019, 1, 1, 0, 0, 0, 0, UTC)
+            'date_created': datetime(2019, 1, 1, tzinfo=timezone.utc)
         }
 
         # Call the function
@@ -1570,7 +1567,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_comment_format_legacy.return_value = 'mock_legacy_comment_body'
         mock_comment = {
             'id': '12345',
-            'date_created': datetime(2019, 1, 1, 0, 0, 0, 0, UTC)
+            'date_created': datetime(2019, 1, 1, tzinfo=timezone.utc)
         }
 
         # Call the function


### PR DESCRIPTION
This PR is the next in the series of refactorings originally set out in https://github.com/release-engineering/Sync2Jira/pull/207 which endeavors to improve code quality in Sync2Jira; this is the follow-on to https://github.com/release-engineering/Sync2Jira/pull/255.

This change is a refinement of #222 which utilizes the simpler timezone support included in the `datetime` package rather than adding the `ZoneInfo` package, and it simplifies the instantiations of timestamps in the unit tests.