### PR TITLE
DRY the Datagrepper query loop

### DIFF
--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -329,34 +329,27 @@ def query(limit=None, **kwargs):
 
     # Set up for paging requests
     all_results = []
-    page = params.get('page', 1)
 
     # Important to set ASC order when paging to avoid duplicates
     params['order'] = 'asc'
 
-    results = get(params=params)
-
-    # Collect the messages
-    all_results.extend(results['raw_messages'])
-
-    # Set up for loop
-    fetched = results['count']
-    total = limit or results['total']
-
-    # Fetch results until no more are left
+    # Fetch results:
+    #  - once, if limit is 0 or None (the default)
+    #  - until we hit the limit
+    #  - until there are no more left to fetch
+    fetched = 0
+    total = limit or 1
     while fetched < total:
-        page += 1
-        params['page'] = page
-
         results = get(params=params)
         count = results['count']
-        fetched += count
 
-        # if we missed the condition and haven't fetched any
-        if count == 0:
+        # Exit the loop if there was nothing to fetch
+        if count <= 0:
             break
 
+        fetched += count
         all_results.extend(results['raw_messages'])
+        params['page'] = params.get('page', 1) + 1
 
     return all_results
 
@@ -380,10 +373,7 @@ def main(runtime_test=False, runtime_config=None):
     :return: Nothing
     """
     # Load config and disable warnings
-    if not runtime_test or not runtime_config:
-        config = load_config()
-    else:
-        config = runtime_config
+    config = runtime_config if runtime_test and runtime_config else load_config()
 
     logging.basicConfig(level=logging.INFO)
     warnings.simplefilter("ignore")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -496,7 +496,8 @@ class TestMain(unittest.TestCase):
         response = m.query()
 
         # Assert everything was called correctly
-        mock_get.assert_called_with(params={'order': 'asc'})
+        mock_get.assert_called_once()
+        self.assertEqual(mock_get.call_args.kwargs['params']['order'], 'asc')
         self.assertEqual(response, ['test_msg'])
 
     @mock.patch(PATH + 'HTTPKerberosAuth')


### PR DESCRIPTION
This PR is the next in the series of refactorings originally set out in https://github.com/release-engineering/Sync2Jira/pull/207 which endeavors to improve code quality in Sync2Jira; this is the follow-on to https://github.com/release-engineering/Sync2Jira/pull/256.

This change tweaks the Datagrepper query loop so that there is a single call to `get()`, rather than having a separate call for the first page and then a loop for subsequent pages.  (And, it replaces an `if`-based assignment with a ternary operation, because who doesn't love a good ternary??  😆)