### PR TITLE
Convert Datagrepper query to a generator

### DIFF
--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -327,9 +327,6 @@ def query(limit=None, **kwargs):
     # Pack up the kwargs into a parameter list for request
     params = deepcopy(kwargs)
 
-    # Set up for paging requests
-    all_results = []
-
     # Important to set ASC order when paging to avoid duplicates
     params['order'] = 'asc'
 
@@ -348,10 +345,10 @@ def query(limit=None, **kwargs):
             break
 
         fetched += count
-        all_results.extend(results['raw_messages'])
-        params['page'] = params.get('page', 1) + 1
+        for result in results['raw_messages']:
+            yield result
 
-    return all_results
+        params['page'] = params.get('page', 1) + 1
 
 
 def get(params):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -493,7 +493,7 @@ class TestMain(unittest.TestCase):
             'total': 1
         }
         # Call the function
-        response = m.query()
+        response = list(m.query())
 
         # Assert everything was called correctly
         mock_get.assert_called_once()


### PR DESCRIPTION
This PR is the next in the series of refactorings originally set out in https://github.com/release-engineering/Sync2Jira/pull/207 which endeavors to improve code quality in Sync2Jira; this is the follow-on to https://github.com/release-engineering/Sync2Jira/pull/257.

This change tweaks the Datagrepper query function so that it acts as a generator instead of returning a list.