### PR TITLE
Pick lint

### DIFF
--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -36,7 +36,7 @@ class Issue(object):
         self.storypoints = storypoints
 
         # First trim the size of the content
-        self.content = trimString(content)
+        self.content = trim_string(content)
 
         # JIRA treats utf-8 characters in ways we don't totally understand, so scrub content down to
         # simple ascii characters right from the start.
@@ -73,7 +73,7 @@ class Issue(object):
             comments.append({
                 'author': comment['author'],
                 'name': comment['name'],
-                'body': trimString(comment['body']),
+                'body': trim_string(comment['body']),
                 'id': comment['id'],
                 'date_created': comment['date_created'],
                 'changed': None
@@ -136,7 +136,7 @@ class PR(object):
         # simple ascii characters right from the start.
         if content:
             # First trim the size of the content
-            self.content = trimString(content)
+            self.content = trim_string(content)
 
             self.content = self.content.encode('ascii', errors='replace').decode('ascii')
 
@@ -164,7 +164,7 @@ class PR(object):
         return u'[%s] %s' % (self.upstream, self._title)
 
     @classmethod
-    def from_github(self, upstream, pr, suffix, config):
+    def from_github(cls, upstream, pr, suffix, config):
         """Helper function to create intermediary object."""
         # Set our upstream source
         upstream_source = 'github'
@@ -175,7 +175,7 @@ class PR(object):
             comments.append({
                 'author': comment['author'],
                 'name': comment['name'],
-                'body': trimString(comment['body']),
+                'body': trim_string(comment['body']),
                 'id': comment['id'],
                 'date_created': comment['date_created'],
                 'changed': None
@@ -198,7 +198,7 @@ class PR(object):
                 suffix = 'closed'
 
         # Return our PR object
-        return PR(
+        return cls(
             source=upstream_source,
             jira_key=match,
             title=pr['title'],
@@ -266,7 +266,7 @@ def matcher(content, comments):
             return None
 
 
-def trimString(content):
+def trim_string(content):
     """
     Helper function to trim a string to ensure it is not over 50000 char
     Ref: https://github.com/release-engineering/Sync2Jira/issues/123

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -87,7 +87,7 @@ DATAGREPPER_URL = "http://apps.fedoraproject.org/datagrepper/raw"
 INITIALIZE = os.getenv('INITIALIZE', '0')
 
 
-def load_config(loader=fedmsg.config.load_config):
+def load_config(loader=fedmsg.config.conf.load_config):
     """
     Generates and validates the config file \
     that will be used by fedmsg and JIRA client.
@@ -103,8 +103,8 @@ def load_config(loader=fedmsg.config.load_config):
 
     # debug mode
     if config.get('sync2jira', {}).get('debug', False):
-        hdlr = logging.FileHandler('sync2jira_main.log')
-        log.addHandler(hdlr)
+        handler = logging.FileHandler('sync2jira_main.log')
+        log.addHandler(handler)
         log.setLevel(logging.DEBUG)
 
     # Validate it
@@ -193,8 +193,8 @@ def initialize_issues(config, testing=False, repo_name=None):
                     raise
         except Exception as e:
             if "API rate limit exceeded" in e.__str__():
-                # If we've hit out API limit:
-                # Sleep for 1 hour and call our function again
+                # If we've hit our API limit, sleep for 1 hour, and call our
+                # function again.
                 log.info("Hit Github API limit. Sleeping for 1 hour...")
                 sleep(3600)
                 if not testing:
@@ -239,8 +239,8 @@ def initialize_pr(config, testing=False, repo_name=None):
                     raise
         except Exception as e:
             if "API rate limit exceeded" in e.__str__():
-                # If we've hit out API limit:
-                # Sleep for 1 hour and call our function again
+                # If we've hit our API limit, sleep for 1 hour, and call our
+                # function again.
                 log.info("Hit Github API limit. Sleeping for 1 hour...")
                 sleep(3600)
                 if not testing:
@@ -282,14 +282,14 @@ def initialize_recent(config):
 
 def handle_msg(msg, suffix, config):
     """
-    Function to handle incomming message from datagrepper
+    Function to handle incoming message from datagrepper
     :param Dict msg: Incoming message
     :param String suffix: Incoming suffix
     :param Dict config: Config dict
     """
     issue = None
     pr = None
-    # Github '.issue.' is used for both PR and Issue
+    # GitHub '.issue.' is used for both PR and Issue
     # Check for that edge case
     if suffix == 'github.issue.comment':
         if 'pull_request' in msg['msg']['issue'] and msg['msg']['action'] != 'deleted':
@@ -363,7 +363,7 @@ def get(params):
 def main(runtime_test=False, runtime_config=None):
     """
     Main function to check for initial sync
-    and listen for fedmgs.
+    and listen for fedmsgs.
 
     :param Bool runtime_test: Flag to indicate if we are performing a runtime test. Default false
     :param Dict runtime_config: Config file to be used if it is a runtime test. runtime_test must be true
@@ -387,7 +387,7 @@ def main(runtime_test=False, runtime_config=None):
             if runtime_test:
                 return
         else:
-            # Pool datagrepper from the last 10 mins
+            # Pull from datagrepper for the last 10 minutes
             log.info("Initialization False. Pulling data from datagrepper...")
             initialize_recent(config)
         try:
@@ -405,14 +405,13 @@ def report_failure(config):
     """
     Helper function to alert admins in case of failure.
 
-
     :param Dict config: Config dict for JIRA
     """
     # Email our admins with the traceback
-    templateLoader = jinja2.FileSystemLoader(
+    template_loader = jinja2.FileSystemLoader(
         searchpath='usr/local/src/sync2jira/sync2jira/')
-    templateEnv = jinja2.Environment(loader=templateLoader, autoescape=True)
-    template = templateEnv.get_template('failure_template.jinja')
+    template_env = jinja2.Environment(loader=template_loader, autoescape=True)
+    template = template_env.get_template('failure_template.jinja')
     html_text = template.render(traceback=traceback.format_exc())
 
     # Send mail

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,7 +54,7 @@ class TestMain(unittest.TestCase):
         loader = lambda: {'sync2jira': {}}
         self._check_for_exception(loader, 'No sync2jira.map section')
 
-    def test_config_validate_mispelled_mappings(self):
+    def test_config_validate_misspelled_mappings(self):
         loader = lambda: {'sync2jira': {'map': {'githob': {}}}, 'jira': {}}
         self._check_for_exception(loader, 'Specified handlers: "githob", must')
 
@@ -64,7 +64,7 @@ class TestMain(unittest.TestCase):
 
     def test_config_validate_all_good(self):
         loader = lambda: {'sync2jira': {'map': {'github': {}}, 'jira': {}}}
-        m.load_config(loader)  # ahhh, no exception.
+        m.load_config(loader)  # Should succeed without an exception.
 
     @mock.patch(PATH + 'u_issue')
     @mock.patch(PATH + 'd_issue')
@@ -366,13 +366,13 @@ class TestMain(unittest.TestCase):
         Tests 'report_failure' function
         """
         # Set up return values
-        mock_templateLoader = MagicMock()
-        mock_templateEnv = MagicMock()
+        mock_template_loader = MagicMock()
+        mock_template_env = MagicMock()
         mock_template = MagicMock()
         mock_template.render.return_value = 'mock_html'
-        mock_templateEnv.get_template.return_value = mock_template
-        mock_jinja2.FileSystemLoader.return_value = mock_templateLoader
-        mock_jinja2.Environment.return_value = mock_templateEnv
+        mock_template_env.get_template.return_value = mock_template
+        mock_jinja2.FileSystemLoader.return_value = mock_template_loader
+        mock_jinja2.Environment.return_value = mock_template_env
 
         # Call the function
         m.report_failure({'sync2jira': {'mailing-list': 'mock_email'}})


### PR DESCRIPTION
This PR is the next in the series of refactorings originally set out in https://github.com/release-engineering/Sync2Jira/pull/207 which endeavors to improve code quality in Sync2Jira; this is the follow-on to https://github.com/release-engineering/Sync2Jira/pull/258.

This change picks a bunch of lint from a few of the modules to make the code "more Pythonic":
- Change `camelCase` names to `snake_case`.
- The first parameter to a class method is conventionally named `cls` and should be used in preference to referencing the class by name.
- Correct the reference to `fedmsg.config.load_config`.
- Replace cryptic/abbreviated variable names when there is no reason not to spell them out.
- Correct misspelled words in comments and test names; wordsmith a couple of comments.