### PR TITLE
Two point fixes

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -978,6 +978,10 @@ def _update_github_project_fields(client, existing, issue,
 
     default_jira_fields = config['sync2jira'].get('default_jira_fields', {})
     for name, values in github_project_fields.items():
+        if name not in dir(issue):
+            log.error(f"Configuration error: github_project_field key, {name:r}, is not in issue object.")
+            continue
+
         log.info(f"Looking at GHP field '{name}' with configuration '{values}'")
         fieldvalue = getattr(issue, name)
         log.info(f"Issue value for field '{name}' is '{fieldvalue}'")

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -87,7 +87,7 @@ DATAGREPPER_URL = "http://apps.fedoraproject.org/datagrepper/raw"
 INITIALIZE = os.getenv('INITIALIZE', '0')
 
 
-def load_config(loader=fedmsg.config.conf.load_config):
+def load_config(loader=lambda: fedmsg.config.conf):
     """
     Generates and validates the config file \
     that will be used by fedmsg and JIRA client.


### PR DESCRIPTION
This PR is the next in the series of revisions originally set out in https://github.com/release-engineering/Sync2Jira/pull/207 which endeavors to improve code quality in Sync2Jira; this is the follow-on to https://github.com/release-engineering/Sync2Jira/pull/259.

This change provides two independent fixes, but they are so tiny that I've batched them into a single PR for efficiency.

- My IDE flags the use of the FedMsg `load_config()` function as deprecated.  The [documentation](https://fedmsg.readthedocs.io/en/latest/api/#fedmsg.config.load_config) doesn't make any such actual statement, but it does indicate that [the `conf` attribute is intended to replace it](https://fedmsg.readthedocs.io/en/latest/api/#fedmsg.config.conf), so I've replaced the reference to the function in the code with a `lambda` which returns the attribute.
- I noted a weak spot in the code where a misconfiguration in the `sync2jira.yaml` file could crash the tool, so I put in a guard to log and skip the case.