### PR TITLE
Refactor and reuse code which adds values from GitHub Project fields

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -989,18 +989,9 @@ def _update_github_project_fields(client, existing, issue,
         log.info(f"Issue value for field '{name}' is '{fieldvalue}'")
         if name == 'storypoints':
             if not isinstance(fieldvalue, int):
-                log.info(f"Story point field value '{fieldvalue}' is a {type(fieldvalue)}, not an 'int'")
-                # FIXME:  The intermediate issue _should_ have either a number
-                #  or None for this value, but the code isn't complete yet; so,
-                #  until that is addressed, cover for it here.
-                try:
-                    fieldvalue = int(fieldvalue)
-                    log.info(f"Story point field value successfully converted to an 'int':  {fieldvalue}")
-                except (TypeError, ValueError) as exc:
-                    if fieldvalue:
-                        log.error(f"Error converting story point value ({fieldvalue}) to int: {exc}")
-                    log.info(f"Skipping story point field with value:  '{fieldvalue}'")
-                    continue
+                if fieldvalue is not None:
+                    log.info(f"Story point field value '{fieldvalue}' is a {type(fieldvalue)}, not an 'int'")
+                continue
             try:
                 jirafieldname = default_jira_fields['storypoints']
                 log.info(f"Jira issue story point field name is:  '{jirafieldname}'")

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -108,7 +108,7 @@ class Issue(object):
             assignee=issue['assignees'],
             status=issue['state'],
             id=issue['id'],
-            storypoints=issue.get('storypoints', ''),
+            storypoints=issue.get('storypoints'),
             upstream_id=issue['number']
         )
 

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -235,7 +235,7 @@ class TestUpstreamIssue(unittest.TestCase):
                 'user': {'login': 'mock_login', 'fullname': 'mock_name'},
                 'milestone': 'mock_milestone',
                 'storypoints': 2,
-                 'priority': ''},
+                'priority': None},
             self.mock_config
         )
         self.mock_github_client.get_repo.assert_called_with('org/repo')


### PR DESCRIPTION
This PR is a follow-on to #239 (benefitting from the results of #240 and #247) which (hopefully!) addresses the problem with updating story point and priority values from GitHub Project fields.

This change refactors the code which performs the field value extractions and updates and moves it into a common subroutine so that it can be used by the FedMsg-driven updates as well as the repo-initialization path.

This change also sanitizes the processing of story points to ensure that the values are either an `int` or `None`.  This allows us to remove the conversion and error handling from the downstream issue code.

While the unit tests for this code pass, it's not really feasible to test it except in production....

FYI: @baijum