### PR TITLE
Revert change to FedMsg loader

### DIFF
--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -87,7 +87,7 @@ DATAGREPPER_URL = "http://apps.fedoraproject.org/datagrepper/raw"
 INITIALIZE = os.getenv('INITIALIZE', '0')
 
 
-def load_config(loader=lambda: fedmsg.config.conf):
+def load_config(loader=fedmsg.config.conf.load_config):
     """
     Generates and validates the config file \
     that will be used by fedmsg and JIRA client.


### PR DESCRIPTION
It looks like the change in #261 to modify the FedMsg configuration loader somehow resulted in missing part of the configuration.  This PR backs out that change until I can figure out how it went awry.