### PR TITLE
Exercise some paranoia accessing GH GraphQL return

### DIFF
--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -231,7 +231,7 @@ def add_project_values(issue, upstream, headers, config):
                       orgname, reponame, issuenumber, response.text)
             return
         data = response.json()
-        gh_issue = data['data']['repository']['issue']
+        gh_issue = data.get('data', {}).get('repository', {}).get('issue')
         if not gh_issue:
             log.debug("GitHub error while fetching issue %s/%s#%s: %s",
                       orgname, reponame, issuenumber, response.text)


### PR DESCRIPTION
This is a follow-on to #263.  Apparently, we cannot assume quite so much about the value returned by the GitHub GraphQL API.  This change makes the code a little more bullet-proof.

FYI:  @baijum 