### PR TITLE
Tweak handling PR messages

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -405,16 +405,15 @@ class TestMain(unittest.TestCase):
         mock_d.sync_with_jira.assert_not_called()
         mock_u.handle_github_message.assert_not_called()
 
-    @mock.patch(PATH + "issue_handlers")
+    @mock.patch.dict(
+        PATH + "issue_handlers", {"github.issue.comment": lambda msg, c: None}
+    )
     @mock.patch(PATH + "u_issue")
     @mock.patch(PATH + "d_issue")
-    def test_handle_msg_no_issue(self, mock_d, mock_u, mock_handlers_issue):
+    def test_handle_msg_no_issue(self, mock_d, mock_u):
         """
         Tests 'handle_msg' function where there is no issue
         """
-        # Set up return values
-        mock_handlers_issue["github.issue.comment"].return_value = None
-
         # Call the function
         m.handle_msg(
             body=self.mock_message_body,
@@ -426,15 +425,16 @@ class TestMain(unittest.TestCase):
         mock_d.sync_with_jira.assert_not_called()
         mock_u.handle_github_message.assert_not_called()
 
-    @mock.patch(PATH + "issue_handlers")
+    @mock.patch.dict(
+        PATH + "issue_handlers", {"github.issue.comment": lambda msg, c: "dummy_issue"}
+    )
     @mock.patch(PATH + "u_issue")
     @mock.patch(PATH + "d_issue")
-    def test_handle_msg(self, mock_d, mock_u, mock_handlers_issue):
+    def test_handle_msg(self, mock_d, mock_u):
         """
         Tests 'handle_msg' function
         """
         # Set up return values
-        mock_handlers_issue["github.issue.comment"].return_value = "dummy_issue"
         mock_u.handle_github_message.return_value = "dummy_issue"
 
         # Call the function


### PR DESCRIPTION
This change reworks the dispatching code in `handle_msg()` removing the preamble special case to generalize the code and ensure that it doesn't miss the existence checks for the message handlers.

It moves the special case which handles certain PR messages as Issues and embeds it into the Issues case.  That is, it reduces the flow to two cases -- Issues and PRs -- checking first to see if the message suffix matches an Issue handler and, if not, then checking if it matches a PR handler.  And, it untangles the two flows so that each reaches its respective completion before returning, instead of coming back together for subsequent conditionals.

If the message suffix matches an Issue handler, _then_ we determine whether the message is actually referencing a PR; otherwise, the sequence of operations is substantially the same as the previous code, with fewer conditionals and state variables.

This change also reworks the upstream issue `handle_github_message()` function's third parameter, replacing the previous "filter request" control with a boolean declaring whether the message is known to reference a PR instead of an Issue.  This allows us to collapse into one test the two discrete configuration checks of whether Issues and PRs, respectively, are being sync'd.  And, it simplifies another check which skips all PRs which are not being closed.

Unfortunately, I also had to tweak two of the unit tests whose mocking of the `issue_handlers` dictionary didn't properly handle using the `get()` method it.