### PR TITLE
Handle upstream issue milestone of `None`

### DIFF
--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -150,7 +150,7 @@ def handle_github_message(msg, config, pr_filter=True):
                 return None
         elif key == "milestone":
             # special handling for milestone: use the number
-            milestone = issue.get(key, {})
+            milestone = issue.get(key) or {}  # Key might exist with value `None`
             actual = milestone.get("number")
             if expected != actual:
                 log.debug("Milestone %s not set on issue: %s", expected, upstream)


### PR DESCRIPTION
Looking at the crash from `2025-01-27 03:02:13,506`, it appears that our defense against missing milestones in upstream issues is not quite sufficient:  apparently, the `"milestone"` key can be present in the upstream issue with a value of `None`, so the trick of using a default value in the `get()` call is not sufficient.  This applies the default both in the case where the key does not exist and the case where the key is false-y (i.e., `None` or any "empty" value).