### PR TITLE
Improve PR Jira issue matcher

### DIFF
--- a/tests/test_intermediary.py
+++ b/tests/test_intermediary.py
@@ -229,18 +229,84 @@ class TestIntermediary(unittest.TestCase):
 
     def test_matcher(self):
         """This tests the matcher function"""
-        # Positive case
-        content = "Relates to JIRA: XYZ-5678"
-        comments = [{"body": "Relates to JIRA: ABC-1234"}]
-        expected = True
-        actual = bool(i.matcher(content, comments))
-        assert expected == actual
+        # Found in content, no comments
+        expected = "XYZ-5678"
+        content = f"Relates to JIRA: {expected}"
+        comments = []
+        actual = i.matcher(content, comments)
+        self.assertEqual(expected, actual)
+
+        # Found in comment, no content
+        expected = "XYZ-5678"
+        content = None
+        comments = [{"body": f"Relates to JIRA: {expected}"}]
+        actual = i.matcher(content, comments)
+        self.assertEqual(expected, actual)
+
+        # Found in content, not spanning comments
+        expected = "XYZ-5678"
+        content = f"Relates to JIRA: {expected}"
+        comments = [
+            {"body": "ABC-1234"},
+            {"body": "JIRA:"},
+            {"body": "to"},
+            {"body": "Relates"},
+        ]
+        actual = i.matcher(content, comments)
+        self.assertEqual(expected, actual)
+
+        # Found in comment, not contents
+        expected = "XYZ-5678"
+        content = "Nothing here"
+        comments = [
+            {"body": "Relates"},
+            {"body": f"Relates to JIRA: {expected}"},
+            {"body": "stuff"},
+        ]
+        actual = i.matcher(content, comments)
+        self.assertEqual(expected, actual)
+
+        # Overridden in comment
+        expected = "XYZ-5678"
+        content = "Relates to JIRA: ABC-1234"
+        comments = [
+            {"body": "Relates"},
+            {"body": f"Relates to JIRA: {expected}"},
+            {"body": "stuff"},
+        ]
+        actual = i.matcher(content, comments)
+        self.assertEqual(expected, actual)
+
+        # Overridden twice in comments
+        expected = "XYZ-5678"
+        content = "Relates to JIRA: ABC-1234"
+        comments = [
+            {"body": "Relates to JIRA: ABC-1235"},
+            {"body": f"Relates to JIRA: {expected}"},
+            {"body": "stuff"},
+        ]
+        actual = i.matcher(content, comments)
+        self.assertEqual(expected, actual)
+
+        # Funky spacing
+        expected = "XYZ-5678"
+        content = f"Relates  to  JIRA:   {expected}"
+        comments = []
+        actual = i.matcher(content, comments)
+        self.assertEqual(expected, actual)
+
+        # Funkier spacing
+        expected = "XYZ-5678"
+        content = f"Relates to JIRA:{expected}"
+        comments = []
+        actual = i.matcher(content, comments)
+        self.assertEqual(expected, actual)
 
         # Negative case
         content = "No JIRAs here..."
         comments = [{"body": "... nor here"}]
-        expected = False
-        actual = bool(i.matcher(content, comments))
-        assert expected == actual
+        expected = None
+        actual = i.matcher(content, comments)
+        self.assertEqual(expected, actual)
 
     # TODO: Add new tests from PR


### PR DESCRIPTION
Springboarding from [the discussion here](https://redhat-internal.slack.com/archives/C058M9PBGEM/p1738566886157029?thread_ts=1738345347.500559&cid=C058M9PBGEM), this PR overhauls the PR-to-Jira matcher code:
- Rework the "magic cookie" regex:
  - make it tolerate whitespace better
  - tighten up the match on the Jira reference a little
  - remove redundant syntax
- Replace the build-a-string-and-search-the-whole-thing approach with one which searches each component separately:
  - I don't think this makes the searching more expensive
  - it saves having to instantiate the combined string
  - it means that we cannot hit on matches which inadvertently cross component boundaries
  - we quit searching on the first match instead of gathering them all for checking later
- Pre-compile the regex for efficiency
- Remove a stale/incorrect code comment
- Remove what looks like an unnecessary re-check
- Add type hints to the function signature

This change also adds a bunch of unit test scenarios for the matcher.
