### PR TITLE
Guard against none-type inputs to regex matching

### DIFF
--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -299,6 +299,8 @@ def matcher(content: Optional[str], comments: list[dict[str, str]]) -> str:
     """
 
     def find_it(input_str: str) -> str:
+        if input_str is None:
+            return None
         match = JIRA_REFERENCE.search(input_str)
         return match.group(1) if match else None
 

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -299,7 +299,7 @@ def matcher(content: Optional[str], comments: list[dict[str, str]]) -> str:
     """
 
     def find_it(input_str: str) -> str:
-        if input_str is None:
+        if not input_str:
             return None
         match = JIRA_REFERENCE.search(input_str)
         return match.group(1) if match else None


### PR DESCRIPTION
We regularly get tracebacks with the following error:

```
File "intermediary.py", line 302, in find_it match = JIRA_REFERENCE.search(input_str) TypeError: expected string or bytes-like object
```

I'm not sure that this is showing up as a None, but that's the most likely scenario.