### PR TITLE
Allow multiple consumers from the messaging queue

### DIFF
--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -177,7 +177,7 @@ def listen(config):
         queue: {
             "durable": True,  # Persist the queue on broker restart
             "auto_delete": False,  # Delete the queue when the client terminates
-            "exclusive": True,  # Disallow multiple simultaneous consumers
+            "exclusive": False,  # Allow multiple simultaneous consumers
             "arguments": {},
         },
     }


### PR DESCRIPTION
This will hopefully resolve our hanging process problem and let crashloops proceed more fluidly.