### PR TITLE
Retry Jira failures in case they are due to expired credentials

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -24,7 +24,7 @@ import difflib
 import logging
 import operator
 import re
-from typing import Optional
+from typing import Optional, Union
 
 # 3rd Party Modules
 from jira import JIRAError
@@ -433,7 +433,7 @@ def assign_user(client, issue, downstream, remove_all=False):
     log.warning("Was not able to assign user %s", issue.assignee[0]["fullname"])
 
 
-def change_status(client, downstream, status, issue):
+def change_status(client, downstream, status, issue: Union[Issue, PR]):
     """
     Change status of JIRA issue.
 

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -42,12 +42,11 @@ def format_comment(pr, pr_suffix, client):
     """
     # Find the pr.reporters JIRA username
     ret = client.search_users(pr.reporter)
-    if len(ret) > 0:
-        # Loop through ret till we find an match
-        for user in ret:
-            if user.displayName == pr.reporter:
-                reporter = f"[~{user.key}]"
-                break
+    # Loop through ret till we find a match
+    for user in ret:
+        if user.displayName == pr.reporter:
+            reporter = f"[~{user.key}]"
+            break
     else:
         reporter = pr.reporter
 

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -21,6 +21,8 @@ import logging
 
 # 3rd Party Modules
 from jira import JIRAError
+from jira.client import Issue as JIRAIssue
+from jira.client import ResultList
 
 # Local Modules
 import sync2jira.downstream_issue as d_issue
@@ -63,14 +65,14 @@ def format_comment(pr, pr_suffix, client):
     return comment
 
 
-def issue_link_exists(client, existing, pr):
+def issue_link_exists(client, existing: JIRAIssue, pr):
     """
     Checks if we've already linked this PR
 
     :param jira.client.JIRA client: JIRA Client
     :param jira.resources.Issue existing: Existing JIRA issue that was found
     :param sync2jira.intermediary.PR pr: Upstream issue we're pulling data from
-    :returns: True/False if the issue exists/does not exists
+    :returns: True/False if the issue exists/does not exist
     """
     # Query for our issue
     for issue_link in client.remote_links(existing):
@@ -80,7 +82,7 @@ def issue_link_exists(client, existing, pr):
     return False
 
 
-def comment_exists(client, existing, new_comment):
+def comment_exists(client, existing: JIRAIssue, new_comment):
     """
     Checks if new_comment exists in existing
     :param jira.client.JIRA client: JIRA Client
@@ -99,7 +101,7 @@ def comment_exists(client, existing, new_comment):
 
 def update_jira_issue(existing, pr, client):
     """
-    Updates an existing JIRA issue (i.e. tags, assignee, comments etc).
+    Updates an existing JIRA issue (i.e. tags, assignee, comments etc.).
 
     :param jira.resources.Issue existing: Existing JIRA issue that was found
     :param sync2jira.intermediary.PR pr: Upstream issue we're pulling data from
@@ -114,7 +116,7 @@ def update_jira_issue(existing, pr, client):
     # See if the issue_link and comment exists
     exists = issue_link_exists(client, existing, pr)
     comment_exist = comment_exists(client, existing, new_comment)
-    # Check if the comment if already there
+    # Check if the comment is already there
     if not exists:
         if not comment_exist:
             log.info(f"Added comment for PR {pr.title} on JIRA {pr.jira_key}")
@@ -162,7 +164,7 @@ def update_transition(client, existing, pr, transition_type):
 
 def sync_with_jira(pr, config):
     """
-    Attempts to sync a upstream PR with JIRA (i.e. by finding
+    Attempts to sync an upstream PR with JIRA (i.e. by finding
     an existing issue).
 
     :param sync2jira.intermediary.PR/Issue pr: PR or Issue object
@@ -214,7 +216,7 @@ def sync_with_jira(pr, config):
 def update_jira(client, pr):
     query = f"Key = {pr.jira_key}"
     try:
-        response = client.search_issues(query)
+        response: ResultList[JIRAIssue] = client.search_issues(query)
         # Throw error and return if nothing could be found
         if len(response) == 0 or len(response) > 1:
             log.warning(f"No JIRA issue could be found for {pr.title}")

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -142,7 +142,6 @@ def load_config(loader=fedmsg.config.load_config):
 
 
 def callback(msg):
-    config = load_config()
     topic = msg.topic
     idx = msg.id
     suffix = ".".join(topic.split(".")[3:])
@@ -151,6 +150,7 @@ def callback(msg):
         log.info("No handler for %r %r %r", suffix, topic, idx)
         return
 
+    config = load_config()
     body = msg.body.get("body") or msg.body
     handle_msg(body, suffix, config)
 


### PR DESCRIPTION
Anecdotal evidence suggests that _Sync2Jira_ crashes every day at about 15:54 UTC due to some sort of Jira error indicating insufficient credentials.  When the pod restarts, everything works fine again.

Having the logs cycle daily is making it hard to observe other instabilities, so I've implemented a simple stop-gap which I hope will address the credentials problem:  in the code which creates the Jira client object, for each of PRs and Issues, I've added a `try` block around the subroutine calls which receive it; if we encounter a Jira exception, the code will create a fresh client and try the operation again.

If my theory is correct that it is an expiring credentials problem, the retry should succeed and we will avoid crashing the pod (if the retry fails, it will let the exception crash the pod as it does now).  Note that the retry will start the update process from the beginning, which means that any partial updates to the Jira ticket will be made a second time.  Hopefully, the effect from this will be benign, and it will be worth the occasional noise to avoid the crash.

In addition to making this change, I added a few other revisions to my branch:
- I've rearranged the logging in the fedmesg consumer code:
  - it looks like the fedmesg client is logging the start and end of each event, so I removed the debug logging messages from our code; and,
  - I added logging for cases where we do _not_ handle events (the cases that we _do_ handle already issue messages to the log), so this way we will see fewer started- and finished-messages with no disposition between them.
- My IDE was flagging a few things in the modules that I was looking at, so I picked a little lint -- mostly fixing typos in comment text and adding type hints to the code.
- There were a couple of places where I made small code quality tweaks.