### PR TITLE
pagure: correct pagure issue topic

### DIFF
--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -208,7 +208,7 @@ def listen(config):
             "org.fedoraproject.prod.github.issue.#",
             "org.fedoraproject.prod.github.pull_request.#",
             # Pagure (Old style)
-            "org.fedoraproject.prod.pagure.issue.#",
+            "io.pagure.prod.pagure.issue.#",
             "org.fedoraproject.prod.pagure.pull-request.#",
         ],
     }


### PR DESCRIPTION
The actual prefix of Pagure issue topic is "io.pagure.prod.pagure.issue" rather than "org.fedoraproject.prod.pagure.issue"

The one for pull-request is still as-is.