### PR TITLE
Handle Jira credentials failures during the server status check

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1148,10 +1148,12 @@ def sync_with_jira(issue, config):
             # We got an error from Jira; if this was a re-try attempt, let the
             # exception propagate (and crash the run).
             if retry:
+                log.info("[Issue] Jira retry failed; aborting")
                 raise
 
             # The error is probably because our access has expired; refresh it
             # and try again.
+            log.info("[Issue] Jira request failed; refreshing the Jira client")
             client = get_jira_client(issue, config)
 
         # Retry the update

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1139,19 +1139,6 @@ def sync_with_jira(issue, config):
     # Create a client connection for this issue
     client = get_jira_client(issue, config)
 
-    # Check the status of the JIRA client
-    if not config["sync2jira"]["develop"] and not check_jira_status(client):
-        log.warning("The JIRA server looks like its down. Shutting down...")
-        raise JIRAError
-
-    if issue.downstream.get("issue_updates"):
-        if (
-            issue.source == "github"
-            and issue.content
-            and "github_markdown" in issue.downstream["issue_updates"]
-        ):
-            issue.content = pypandoc.convert_text(issue.content, "jira", format="gfm")
-
     retry = False
     while True:
         try:
@@ -1172,6 +1159,19 @@ def sync_with_jira(issue, config):
 
 
 def update_jira(client, config, issue):
+    # Check the status of the JIRA client
+    if not config["sync2jira"]["develop"] and not check_jira_status(client):
+        log.warning("The JIRA server looks like its down. Shutting down...")
+        raise RuntimeError("Jira server status check failed; aborting...")
+
+    if issue.downstream.get("issue_updates"):
+        if (
+            issue.source == "github"
+            and issue.content
+            and "github_markdown" in issue.downstream["issue_updates"]
+        ):
+            issue.content = pypandoc.convert_text(issue.content, "jira", format="gfm")
+
     # First, check to see if we have a matching issue using the new method.
     # If we do, then just bail out.  No sync needed.
     log.info("Looking for matching downstream issue via new method.")

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -24,7 +24,7 @@ import difflib
 import logging
 import operator
 import re
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 # 3rd Party Modules
 from jira import JIRAError
@@ -1065,7 +1065,10 @@ def _update_description(existing, issue):
         log.info("Updated description")
 
 
-def _update_on_close(existing, issue, updates):
+UPDATE_ENTRY = Union[str, dict[str, Union[str, dict[str, Any]]]]
+
+
+def _update_on_close(existing, issue, updates: list[UPDATE_ENTRY]):
     """Update downstream Jira issue when upstream issue was closed
 
     Example update configuration:
@@ -1088,11 +1091,12 @@ def _update_on_close(existing, issue, updates):
     :param dict updates: update configuration
     :return: None
     """
-    on_close_updates = None
     for item in updates:
-        if "on_close" in item:
-            on_close_updates = item["on_close"]
-            break
+        if isinstance(item, dict):
+            if on_close_updates := item.get("on_close"):
+                break
+    else:
+        on_close_updates = None
 
     if not on_close_updates:
         return

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -193,10 +193,12 @@ def sync_with_jira(pr, config):
             # We got an error from Jira; if this was a re-try attempt, let the
             # exception propagate (and crash the run).
             if retry:
+                log.info("[PR] Jira retry failed; aborting")
                 raise
 
             # The error is probably because our access has expired; refresh it
             # and try again.
+            log.info("[PR] Jira request failed; refreshing the Jira client")
             client = d_issue.get_jira_client(pr, config)
 
         # Retry the update

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -308,7 +308,7 @@ def handle_msg(body, suffix, config):
             # Handle this PR update as though it were an Issue, if that's
             # acceptable to the configuration.
             if not (pr := handler(body, config, is_pr=True)):
-                log.info("Not handling PR update -- not configured")
+                log.info("Not handling PR issue update -- not configured")
                 return
             # PRs require additional handling (Issues do not have suffix, and
             # reporter needs to be reformatted).

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -180,12 +180,10 @@ class TestDownstreamIssue(unittest.TestCase):
     def test_get_existing_newstyle(self, client):
         config = self.mock_config
 
-        class MockIssue(object):
-            downstream = {"key": "value"}
-            title = "A title, a title..."
-            url = "http://threebean.org"
-
-        issue = MockIssue()
+        issue = MagicMock()
+        issue.downstream = {"key": "value"}
+        issue.title = "A title, a title..."
+        issue.url = "http://threebean.org"
         mock_results_of_query = MagicMock()
         mock_results_of_query.fields.summary = "A title, a title..."
 

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -562,7 +562,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_check_jira_status.return_value = False
 
         # Call the function
-        with self.assertRaises(JIRAError):
+        with self.assertRaises(RuntimeError):
             d.sync_with_jira(issue=self.mock_issue, config=self.mock_config)
 
         # Assert all calls were made correctly


### PR DESCRIPTION
This change is a follow-on to #311.  That change covered the Jira update request, but it did not cover the preceding Jira status check (which is just a general query), so, if the credentials go bad on us, the status check incurs an exception (rather than returning `True` or `False`) and we die before we get a chance to try refreshing our credentials.  This change is basically a lift-and-shift, moving the status check code under the credentials failure handling code.  (There are two instances of this code, one for issues and one for PRs; in the PR case, moving the code also required adding a parameter to the subroutine signature.)

This PR also includes several other small changes:
- The Jira server status check was raising a `JIRAError` when the check failed.  It was raising the object _class_ instead of an instance of the object, and it wasn't supplying any explanatory message text for why the error was being raised.  Rather than commandeering the Jira client's object, I changed the exception to `RuntimeError` and added suitable message text.  This necessitated a corresponding tweak to the unit test code.
- While I was in the unit test code, my IDE flagged a couple of lint issues.  To address the first, I replaced a custom mock object with a `MagicMock`.  To address the second, I added a type hint to the `_update_on_close()` signature.
- In the process of working on `_update_on_close()`, I decided to tighten up the code which traverses the updates list.  The list is a heterogenous collection of strings and dictionaries, and the traversal is looking for items which contain `"on_close"`; however, the match that we want is a key in a dictionary item and not a string which happens to contain that sequence of characters.  So, I made the check contingent upon the item being a `dict`, and I applied a couple of optimizations to the flow.
- Finally, I tweaked the logging:  I disambiguated two log messages in the main module, and we should now get messages when we attempt to retry a Jira query due to a credentials problem.

The changes are spread across three commits to make them easier to review.  They can be squashed when this PR is merged.