### PR TITLE
Log inaccessible GitHub repos, and avoid crashing on unhandled exceptions

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -117,12 +117,12 @@ def get_jira_client(issue, config):
 
     # Use the Jira instance set in the issue config. If none then
     # use the configured default jira instance.
-    jira_instance = issue.downstream.get("jira_instance", False)
-    if not jira_instance:
-        jira_instance = config["sync2jira"].get("default_jira_instance", False)
+    jira_instance = issue.downstream.get(
+        "jira_instance", config["sync2jira"].get("default_jira_instance")
+    )
     if not jira_instance:
         log.error("No jira_instance for issue and there is no default in the config")
-        raise Exception
+        raise Exception("No configured jira_instance for issue")
 
     client = jira.client.JIRA(**config["sync2jira"]["jira"][jira_instance])
     return client
@@ -201,21 +201,15 @@ def _matching_jira_issue_query(client, issue, config, free=False):
         return results_of_query
 
 
-def find_username(issue, config):
+def find_username(_issue, config):
     """
     Finds JIRA username for an issue object.
 
-    :param sync2jira.intermediary.Issue issue: Issue object
+    :param sync2jira.intermediary.Issue _issue: Issue object (not used)
     :param Dict config: Config dict
     :returns: Username string
     :rtype: String
     """
-    jira_instance = issue.downstream.get("jira_instance", False)
-    if not jira_instance:
-        jira_instance = config["sync2jira"].get("default_jira_instance", False)
-    if not jira_instance:
-        log.error("No jira_instance for issue and there is no default in the config")
-        raise Exception
     return config["sync2jira"]["jira_username"]
 
 

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -298,7 +298,7 @@ def matcher(content: Optional[str], comments: list[dict[str, str]]) -> str:
     :rtype: Bool
     """
 
-    def find_it(input_str: str) -> str:
+    def find_it(input_str: str) -> Optional[str]:
         if not input_str:
             return None
         match = JIRA_REFERENCE.search(input_str)

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -29,7 +29,9 @@ import warnings
 # 3rd Party Modules
 import fedmsg.config
 import fedora_messaging.api
+from github import GithubException
 import jinja2
+from jira import JIRAError
 
 # Local Modules
 import sync2jira.downstream_issue as d_issue
@@ -152,7 +154,14 @@ def callback(msg):
 
     config = load_config()
     body = msg.body.get("body") or msg.body
-    handle_msg(body, suffix, config)
+    try:
+        handle_msg(body, suffix, config)
+    except GithubException as e:
+        log.error("Unexpected GitHub error: %s", e)
+    except JIRAError as e:
+        log.error("Unexpected Jira error: %s", e)
+    except Exception as e:
+        log.exception("Unexpected error.", exc_info=e)
 
 
 def listen(config):

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 import logging
 from urllib.parse import urlencode
 
-from github import Github
+from github import Github, UnknownObjectException
 import requests
 
 import sync2jira.intermediary as i
@@ -289,7 +289,14 @@ def reformat_github_issue(issue, upstream, github_client):
         issue["comments"] = []
     else:
         # We have multiple comments and need to make api call to get them
-        repo = github_client.get_repo(upstream)
+        try:
+            repo = github_client.get_repo(upstream)
+        except UnknownObjectException:
+            logging.warning(
+                "GitHub repo %r not found (has it been deleted or made private?)",
+                upstream,
+            )
+            raise
         github_issue = repo.get_issue(number=issue["number"])
         issue["comments"] = reformat_github_comments(github_issue.get_comments())
 

--- a/sync2jira/upstream_pr.py
+++ b/sync2jira/upstream_pr.py
@@ -19,7 +19,7 @@
 
 import logging
 
-from github import Github
+from github import Github, UnknownObjectException
 
 import sync2jira.intermediary as i
 import sync2jira.upstream_issue as u_issue
@@ -79,7 +79,14 @@ def reformat_github_pr(pr, upstream, github_client):
         pr["comments"] = []
     else:
         # We have multiple comments and need to make api call to get them
-        repo = github_client.get_repo(upstream)
+        try:
+            repo = github_client.get_repo(upstream)
+        except UnknownObjectException:
+            logging.warning(
+                "GitHub repo %r not found (has it been deleted or made private?)",
+                upstream,
+            )
+            raise
         github_pr = repo.get_pull(number=pr["number"])
         pr["comments"] = u_issue.reformat_github_comments(
             github_pr.get_issue_comments()


### PR DESCRIPTION
Recently, we've had a few crashes triggered by attempts to access a GitHub repo which either doesn't exist or was made private.  The root-cause problem in both cases was a bad configuration file entry, but, since it doesn't become evident until there is an upstream update, having the tool crash seems like a malfeature.

This change adds a `try` block around each of the two GitHub client calls which trigger the crash, so that we can properly log the trigger at the point where it occurs, and it adds a `try` block in the FedMsg callback function which logs and dismisses the exception, so that we avoid crashing the tool (and we will no longer get the elaborate output from FedMsg suggesting that we open a bug report...).

Logging the point of failure is, I think, uncontroversial.  The question is, do we want to include the other `try` block (and do we want to keep it in the form which I have presented?)?  This will ensure that the tool does not crash as a result of attempting to process a message.  However, it will also decrease the visibility of catastrophic problems (like config errors), because the pod will no longer crash, and instead we'll just log the failures after effectively ignoring the FedMsg and we'll continue operation.  I'm not sure what the implications of this trade-off are.

This PR also contains a few code quality changes that I bumped into while making the main change:
- There were a couple of places where we were `raise`'ing an `Exception` class object instead of an instance.  While this is permissible in Python and works more or less as expected, the resulting diagnostics don't contain much information (i.e., they report a generic `Exception` with no message text) so it's a lousy user experience.  In one case, I instantiated the class with useful text.  (The other case I simply removed; see below.)
- The code leading up to the `raise` was not making the best use of the `dict.get()` calls, so I improved that.
- The `find_username()` function (which was the site of the other bare `raise Exception`) contained several lines constructing and checking a value which it ultimately did not use.  So, I deleted those lines.  This left one of its parameters unused, so I renamed it with a leading underscore which marks it as "unused", and updated the docstring to match.  (The remaining function is now a one-liner which we should consider just in-lining at the two places where it is called, but I wasn't interested in going that far in this PR.)
- I corrected the type hint for another function.