### PR TITLE
Handle downstream issue which has no description

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -336,7 +336,6 @@ def attach_link(client, downstream, remote_link):
     :rtype: jira.resources.Issue
     """
     log.info("Attaching tracking link %r to %r", remote_link, downstream.key)
-    modified_desc = downstream.fields.description + " "
 
     # This is crazy.  Querying for application links requires admin perms which
     # we don't have, so duck-punch the client to think it has already made the
@@ -350,6 +349,7 @@ def attach_link(client, downstream, remote_link):
     # gets re-indexed, otherwise our searches won't work. Also, Handle some
     # weird API changes here...
     log.debug("Modifying desc of %r to trigger re-index.", downstream.key)
+    modified_desc = (downstream.fields.description or "") + " "
     downstream.update({"description": modified_desc})
 
     return downstream


### PR DESCRIPTION
Apparently, when a Jira issue contains no description, the `description` field is set to `None` in the tool's representation of the downstream issue.  This is awkward when we try to update it, because we apparently expect it to be a string.

This change defends against this case by conditionally using an empty string for the field value if the value is false-y.  (I also moved the relevant assignment from its previous position in the code to the block which includes a description of what is happening.)