### PR TITLE
Attempt to fix schema warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pypandoc_binary
 urllib3
 jinja2
 flask
+webhook-to-fedora-messaging-messages


### PR DESCRIPTION
Nearly every entry in the log starts with
```
[2025-04-04 16:20:42,953] WARNING: The schema "webhook_to_fedora_messaging.github.message_v1" is not in the schema registry! You can install the missing schema from package 'webhook_to_fedora_messaging_messages'. Falling back to the default schema...
```
and it's gotten annoying.  😇 

This PR attempts to address this by adding the package which the message is whining about, to see if it makes the messages go away.  I don't think this change will hurt anything, so I figured we could try deploying it and see if we win.