### PR TITLE
Remove diacritics

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -18,8 +18,6 @@
 # Authors:  Ralph Bean <rbean@redhat.com>
 
 from datetime import datetime, timezone
-
-# Python Standard Library Modules
 import difflib
 import logging
 import operator
@@ -27,12 +25,10 @@ import re
 from typing import Any, Optional, Union
 import unicodedata
 
-# 3rd Party Modules
 from jira import JIRAError
 import jira.client
 import pypandoc
 
-# Local Modules
 from sync2jira.intermediary import Issue, PR
 
 # The date the service was upgraded
@@ -1008,26 +1004,23 @@ def _update_tags(updates, existing, issue):
 
 def _build_description(issue):
     # Build the description of the JIRA issue
-    if "description" in issue.downstream.get("issue_updates", {}):
-        description = "Upstream description: {quote}%s{quote}" % issue.content
-    else:
-        description = ""
+    issue_updates = issue.downstream.get("issue_updates", {})
+    description = ""
+    if "description" in issue_updates:
+        description = f"Upstream description: {{quote}}{issue.content}{{quote}}"
 
-    if any("transition" in item for item in issue.downstream.get("issue_updates", {})):
+    if any("transition" in item for item in issue_updates):
         # Just add it to the top of the description
         formatted_status = "Upstream issue status: " + issue.status
         description = formatted_status + "\n" + description
 
     if issue.reporter:
         # Add to the description
-        description = "[%s] Upstream Reporter: %s\n%s" % (
-            issue.id,
-            issue.reporter["fullname"],
-            description,
-        )
+        prefix = f"[{issue.id}] Upstream Reporter: {issue.reporter['fullname']}\n"
+        description = prefix + description
 
     # Add the url if requested
-    if "url" in issue.downstream.get("issue_updates", {}):
+    if "url" in issue_updates:
         description = description + f"\nUpstream URL: {issue.url}"
 
     # It seems that our Jira service won't tolerate characters outside the


### PR DESCRIPTION
For no obvious reason, Jira is returning a `403`/`Access Denied` response when we try to create the downstream issue for [containers/buildah/issues/#6066](https://github.com/containers/buildah/issues/6066).  Since we perform this operation successfully on a routine basis for other upstream issues, and since it fails reliably for this particular issue, I assume that the problem is with the contents of the issue itself.

My best guess is that the name of the upstream reporter, `Jiri Daněk`, is the source of the problem:  the penultimate letter of his surname is not an ASCII or LATIN-1 character -- it's a two-byte or 16-bit character -- and I bet our creaky old Jira service cannot handle it (in two-byte form, the first byte has the high bit set, which might be a problem all by itself).

This PR adds a function which replaces characters that have diacritics with their ASCII counterparts (so `ě` becomes `e`), and applies that function to the issue description before passing it to Jira.  Hopefully, this will allow the creation request to succeed without causing too much damage.  (In Rover, Jiri's surname is spelled with an `e`.)

In addition, while I was editing the `_build_description()` function, I made some small code quality improvements, which I've included in a separate commit:
- refactored the repeated dictionary lookup, caching the result in a local variable
- changed the initialization of the `description` variable to an unconditional assignment with a conditional update, instead of having it instantiated in both branches of the `if` statement
- replaced the Python2 string interpolations with f-strings
- removed the comments from the blocks of imports -- now that we're using `isort`, it will manage these for us, so we don't need the annotations (and, without them, we can properly keep all of the Python standard library packages together in the same block).