### PR TITLE
Slight change to downstream assignee lookup

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -408,9 +408,7 @@ def assign_user(client, issue, downstream, remove_all=False):
         return
 
     # Make API call to get a list of users
-    users = client.search_assignable_users_for_issues(
-        fullname, project=issue.downstream["project"]
-    )
+    users = client.search_assignable_users_for_issues(fullname, issueKey=downstream.key)
 
     # Loop through the query
     for user in users:

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -95,6 +95,7 @@ class TestDownstreamIssue(unittest.TestCase):
         self.mock_downstream = MagicMock()
         self.mock_downstream.id = 1234
         self.mock_downstream.fields.labels = ["tag3", "tag4"]
+        self.mock_downstream.key = "downstream_issue_key"
         mock_version1 = MagicMock()
         mock_version1.name = "fixVersion3"
         mock_version2 = MagicMock()
@@ -238,7 +239,7 @@ class TestDownstreamIssue(unittest.TestCase):
         # Assert that all calls mocked were called properly
         self.mock_downstream.update({"assignee": {"name": 1234}})
         mock_client.search_assignable_users_for_issues.assert_called_with(
-            "mock_assignee", project="mock_project"
+            "mock_assignee", issueKey=self.mock_downstream.key
         )
 
     @mock.patch("jira.client.JIRA")
@@ -261,7 +262,7 @@ class TestDownstreamIssue(unittest.TestCase):
         # Assert that all calls mocked were called properly
         mock_client.assign_issue.assert_called_with(1234, "mock_owner")
         mock_client.search_assignable_users_for_issues.assert_called_with(
-            "mock_assignee", project="mock_project"
+            "mock_assignee", issueKey=self.mock_downstream.key
         )
 
     @mock.patch("jira.client.JIRA")
@@ -285,7 +286,7 @@ class TestDownstreamIssue(unittest.TestCase):
         # Assert that all calls mocked were called properly
         mock_client.assign_issue.assert_not_called()
         mock_client.search_assignable_users_for_issues.assert_called_with(
-            "mock_assignee", project="mock_project"
+            "mock_assignee", issueKey=self.mock_downstream.key
         )
 
     @mock.patch("jira.client.JIRA")


### PR DESCRIPTION
We are occasionally seeing warnings in the logs about being unable to assign a downstream issue to a person who apparently should be a valid assignee.  Looking at the documentation for  `jira.client.search_assignable_users_for_issues()`, which we use to generate the list of valid candidates, it says,

> When searching for eligible creators, specify a project. When searching for eligible assignees, specify an issue key.

We're currently specifying a project, but we're looking for an assignee.  This PR changes the call to specify the issue key, instead (and modified the unit test assertions to match).

The other commit in this branch is a bunch of little code quality tweaks.
