### PR TITLE
Remove diacritics 2 fix

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -427,9 +427,13 @@ def assign_user(client, issue, downstream, remove_all=False):
     owner = issue.downstream.get("owner")
     if owner:
         client.assign_issue(downstream.id, owner)
-        log.warning("Assigned %s to owner: %s", issue.title, owner)
+        log.info("Assigned %s to owner: %s", issue.title, owner)
         return
-    log.warning("Was not able to assign user %s", issue.assignee[0]["fullname"])
+    log.info(
+        "Unable to assign %s from upstream assignees %s",
+        issue.url,
+        [a["fullname"] for a in issue.assignee],
+    )
 
 
 def change_status(client, downstream, status, issue: Union[Issue, PR]):

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -358,6 +358,28 @@ class TestDownstreamIssue(unittest.TestCase):
             "mock_assignee", issueKey=self.mock_downstream.key
         )
 
+    @mock.patch(PATH + "match_user")
+    @mock.patch("jira.client.JIRA")
+    def test_assign_user_none(self, mock_client, mock_match_user):
+        """
+        Test `assign_user()` when no upstream user is available and there is
+        no configured owner for the project.
+        """
+        # Set up return values
+        self.mock_issue.assignee = []
+        self.mock_issue.downstream.pop("owner")
+
+        # Call the assign user function
+        d.assign_user(
+            issue=self.mock_issue, downstream=self.mock_downstream, client=mock_client
+        )
+
+        # Assert that all calls mocked were called properly
+        mock_match_user.assert_not_called()
+        mock_client.search_assignable_users_for_issues.assert_not_called()
+        self.mock_downstream.update.assert_not_called()
+        mock_client.assign_issue.assert_not_called()
+
     @mock.patch("jira.client.JIRA")
     def test_assign_user_remove_all(self, mock_client):
         """


### PR DESCRIPTION
With the changes in #326, we now call `assign_user()` in cases where we did not before, so that it can apply fallback policies for selecting assignees during issue updates.  This uncovered an edge case in the logging for failures-to-assign which now results in an `IndexError` exception (which, happily, we catch and log without crashing!).

This PR provides a unit test which replicates the failure case and enhances the `logging` call in question to handle the case gracefully.

It also downgrades the message (and another fallback message) from `WARNING` to `INFO`-level, since I think these now represent "normal" modes of operation.  (I think they are still worth noting in the log -- it's just not worth flagging them for scrutiny.)

While I was thinking about logging, I did a quick polishing-pass over the calls in the downstream module and added a second commit to the branch:
- The current code tends to identify up- and downstream issues via their titles/summaries.  These tend to be hard to pick out when scanning the log, and they are difficult to use to find the issue in the up- or downstream databases.  So, I replaced the ones which are really just ID references with the upstream issue URL and/or the downstream "key" (e.g., `PROJECT-123`).
- In one spot, moved arugents from a Python2 string interpolation to the logging call argument list.
- In one spot where we log an exception, added the exception string to the log message.
- In one spot where we are dumping out a bunch of debug information, I changed the messages from `INFO`-level to `DEBUG`-level.  _Let me know if this is undesirable.  Alternatively, let me know if I should just delete the code...._
- Added quotes around the title text in the initial "Considering" log entry.