### PR TITLE
Fix upstream assignee of `None` and remove a superfluous logging argument

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -437,7 +437,6 @@ def assign_user(
         downstream.key,
         [a["fullname"] for a in issue.assignee],
         issue.url,
-        [a["fullname"] for a in issue.assignee],
     )
 
 
@@ -872,7 +871,9 @@ def _update_assignee(client, existing, issue, overwrite):
     :returns: Nothing
     """
 
-    us_exists = bool(issue.assignee and issue.assignee[0])
+    us_exists = bool(
+        issue.assignee and issue.assignee[0] and issue.assignee[0].get("fullname")
+    )
     ds_exists = bool(existing.fields.assignee) and hasattr(
         existing.fields.assignee, "displayName"
     )
@@ -1224,5 +1225,7 @@ def update_jira(client, config, issue):
 
 def remove_diacritics(text):
     """Convert text from UTF-8 to its ASCII equivalent"""
+    if not text:
+        return ""
     normalized_text = unicodedata.normalize("NFD", text)
     return "".join(c for c in normalized_text if not unicodedata.combining(c))

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -935,12 +935,14 @@ class TestDownstreamIssue(unittest.TestCase):
                 None,  # upstream assignee exists and assignments are equal: not called
                 None,  # upstream assignee exists and assignments differ only in diacritics: not called
                 False,  # upstream assignee exists and assignments are different: called with remove_all=False
+                True,  # upstream assignee has a fullname of None: called with remove_all=True
                 True,  # upstream assignee does not exist: called with remove_all=True
                 True,  # upstream assignee is an empty list: called with remove_all=True
                 #    - downstream assignee does not exist
                 False,  # upstream assignee exists: called with remove_all=False
                 False,  # upstream assignee exists: called with remove_all=False
                 False,  # upstream assignee exists: called with remove_all=False
+                False,  # upstream assignee has a fullname of None: called with remove_all=False
                 False,  # upstream assignee does not exist: called with remove_all=False
                 False,  # upstream assignee is an empty list: called with remove_all=False
                 # - overwrite = False
@@ -948,12 +950,14 @@ class TestDownstreamIssue(unittest.TestCase):
                 None,  # upstream assignee exists and assignments are equal: not called
                 None,  # upstream assignee exists and assignments differ only in diacritics: not called
                 None,  # upstream assignee exists and assignments are different: not called
+                None,  # upstream assignee has a fullname of None: not called
                 None,  # upstream assignee does not exist: not called
                 None,  # upstream assignee is an empty list: not called
                 #    - downstream assignee does not exist
                 False,  # upstream assignee exists: called with remove_all=False
                 False,  # upstream assignee exists: called with remove_all=False
                 False,  # upstream assignee exists: called with remove_all=False
+                False,  # upstream assignee has a fullname of None: called with remove_all=False
                 False,  # upstream assignee does not exist: called with remove_all=False
                 False,  # upstream assignee is an empty list: called with remove_all=False
             )
@@ -966,11 +970,15 @@ class TestDownstreamIssue(unittest.TestCase):
                 else:
                     setattr(self.mock_downstream.fields.assignee, "displayName", match)
 
-                for us in (match, "Èŕìḱ", "Bob", None, []):
-                    if not us:
-                        self.mock_issue.assignee = us
-                    else:
-                        self.mock_issue.assignee = [{"fullname": us}]
+                for us in (
+                    [{"fullname": match}],
+                    [{"fullname": "Èŕìḱ"}],
+                    [{"fullname": "Bob"}],
+                    [{"fullname": None}],
+                    None,
+                    [],
+                ):
+                    self.mock_issue.assignee = us
 
                     d._update_assignee(
                         client=mock_client,

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -7,6 +7,7 @@ from jira import JIRAError
 import jira.client
 
 import sync2jira.downstream_issue as d
+from sync2jira.downstream_issue import remove_diacritics
 from sync2jira.intermediary import Issue
 
 PATH = "sync2jira.downstream_issue."
@@ -1536,3 +1537,15 @@ class TestDownstreamIssue(unittest.TestCase):
             )
             self.mock_downstream.update.assert_not_called()
             mock_client.add_comment.assert_not_called()
+
+    def test_remove_diacritics(self):
+        scenarios = [
+            ("Èŕìḱ", "Erik"),
+            ("Erik", "Erik"),
+            ("", ""),
+            (None, ""),
+        ]
+
+        for text, expected in scenarios:
+            actual = remove_diacritics(text)
+            self.assertEqual(actual, expected)


### PR DESCRIPTION
This PR addresses a couple of faults in #327.

First, one of the logging calls tweaked in that PR ended up with an extra argument parameter, and this causes the call to fail.  This PR removes the superfluous argument.

Second, it turns out that an upstream issue can have an assignee with a `"fullname"` key value of `None`, which triggers an exception when we try to treat it as a string.  This PR addresses this in two ways:  it detects the situation and avoids referencing the value, considering the issue to be "unassigned" (rather than "assigned to nothing"); but, also, the function which was incurring the exception now guards against the condition, as well.

In addition to those changes, this PR adds a case to the applicable unit test to generate this condition, to ensure that it is handled appropriately.  (And, I reworked the test case slightly, since the addition of one more wrinkle made the existing code kind of hokey.)

Finally, I added a unit test for `remove_diacritics()`.