### PR TITLE
Use GitHub issue type (if present) for the Jira issue type

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -625,9 +625,8 @@ def _create_jira_issue(client, issue, config):
         )
         client.add_comment(downstream, comment)
     if len(preferred_types) > 1:
-        comment = "Some labels look like issue types but were not considered:" + str(
-            {preferred_types[1:]}
-        )
+        comment = "Some labels look like issue types but were not considered:  "
+        comment += str(preferred_types[1:])
         client.add_comment(downstream, comment)
 
     remote_link = dict(url=issue.url, title=remote_link_title)

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -488,10 +488,10 @@ def _get_preferred_issue_types(config, issue):
     """
     Determine the appropriate issue type to specify when creating the
     downstream (Jira) issue.  In order of preference:
-     - the upstream issue type (if any)
      - the issue type(s) from the mapping in the configuration file (if
         present), selected based on the upstream "tags" (labels)
      - the default issue type configured for the project (if any)
+     - the upstream issue type (if any)
      - "Story" if the issue title contains "RFE"
      - otherwise, "Bug".
 
@@ -512,9 +512,6 @@ def _get_preferred_issue_types(config, issue):
     #     'bug': 'Bug',
     #     'enhancement': 'Story'
     #   }
-    if issue.issue_type:
-        return [issue.issue_type]
-
     cmap = config["sync2jira"].get("map", {})
     conf = cmap.get("github", {}).get(issue.upstream, {})
 
@@ -528,6 +525,9 @@ def _get_preferred_issue_types(config, issue):
 
     if issue_type := conf.get("type"):
         return [issue_type]
+
+    if issue.issue_type:
+        return [issue.issue_type]
 
     if "RFE" in issue.title:
         return ["Story"]

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -516,11 +516,9 @@ def _get_preferred_issue_types(config, issue):
     conf = cmap.get("github", {}).get(issue.upstream, {})
 
     if issue_types := conf.get("issue_types"):
-        type_list = [
-            issue_type for tag, issue_type in issue_types.items() if tag in issue.tags
-        ]
-        type_list.sort()
+        type_list = [v for k, v in issue_types.items() if k in issue.tags]
         if type_list:
+            type_list.sort()
             return type_list
 
     if issue_type := conf.get("type"):

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -425,6 +425,14 @@ def assign_user(
                 downstream.update({"assignee": {"name": match_name}})
                 return
 
+    if issue.assignee:
+        log.warning(
+            "Unable to assign %s from upstream assignees %s in %s",
+            downstream.key,
+            str([a.get("fullname", "<no-fullname>") for a in issue.assignee]),
+            issue.url,
+        )
+
     # No downstream match for the upstream assignee; if there is a configured
     # owner for the project, assign it to them.
     owner = issue.downstream.get("owner")
@@ -432,12 +440,6 @@ def assign_user(
         client.assign_issue(downstream.id, owner)
         log.info("Assigned %s to owner: %s", downstream.key, owner)
         return
-    log.info(
-        "Unable to assign %s from upstream assignees %s in %s",
-        downstream.key,
-        [a["fullname"] for a in issue.assignee],
-        issue.url,
-    )
 
 
 def change_status(client, downstream, status, issue: Union[Issue, PR]):

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -88,18 +88,7 @@ class Issue(object):
     def from_github(cls, upstream, issue, config):
         """Helper function to create an intermediary Issue object."""
         upstream_source = "github"
-        comments = []
-        for comment in issue["comments"]:
-            comments.append(
-                {
-                    "author": comment["author"],
-                    "name": comment["name"],
-                    "body": trim_string(comment["body"]),
-                    "id": comment["id"],
-                    "date_created": comment["date_created"],
-                    "changed": None,
-                }
-            )
+        comments = reformat_github_comments(issue)
 
         # Reformat the state field
         if issue["state"]:
@@ -218,18 +207,7 @@ class PR(object):
         upstream_source = "github"
 
         # Format our comments
-        comments = []
-        for comment in pr["comments"]:
-            comments.append(
-                {
-                    "author": comment["author"],
-                    "name": comment["name"],
-                    "body": trim_string(comment["body"]),
-                    "id": comment["id"],
-                    "date_created": comment["date_created"],
-                    "changed": None,
-                }
-            )
+        comments = reformat_github_comments(pr)
 
         # Build our URL
         url = pr["html_url"]
@@ -269,6 +247,20 @@ class PR(object):
             suffix=suffix,
             match=match,
         )
+
+
+def reformat_github_comments(issue):
+    return [
+        {
+            "author": comment["author"],
+            "name": comment["name"],
+            "body": trim_string(comment["body"]),
+            "id": comment["id"],
+            "date_created": comment["date_created"],
+            "changed": None,
+        }
+        for comment in issue["comments"]
+    ]
 
 
 def map_fixVersion(mapping, issue):

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -41,6 +41,7 @@ class Issue(object):
         id,
         storypoints,
         upstream_id,
+        issue_type,
         downstream=None,
     ):
         self.source = source
@@ -68,6 +69,7 @@ class Issue(object):
         self.status = status
         self.id = str(id)
         self.upstream_id = upstream_id
+        self.issue_type = issue_type
         if not downstream:
             self.downstream = config["sync2jira"]["map"][self.source][upstream]
         else:
@@ -106,6 +108,11 @@ class Issue(object):
             elif issue["state"] == "closed":
                 issue["state"] = "Closed"
 
+        # Get the issue type if any
+        issue_type = issue.get("type")
+        if isinstance(issue_type, dict):
+            issue_type = issue_type.get("name")
+
         # Perform any mapping
         mapping = config["sync2jira"]["map"][upstream_source][upstream].get(
             "mapping", []
@@ -132,6 +139,7 @@ class Issue(object):
             id=issue["id"],
             storypoints=issue.get("storypoints"),
             upstream_id=issue["number"],
+            issue_type=issue_type,
         )
 
     def __repr__(self):

--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -38,7 +38,7 @@ class Issue(object):
         reporter,
         assignee,
         status,
-        id,
+        id_,
         storypoints,
         upstream_id,
         issue_type,
@@ -67,7 +67,7 @@ class Issue(object):
         self.reporter = reporter
         self.assignee = assignee
         self.status = status
-        self.id = str(id)
+        self.id = str(id_)
         self.upstream_id = upstream_id
         self.issue_type = issue_type
         if not downstream:
@@ -86,7 +86,7 @@ class Issue(object):
 
     @classmethod
     def from_github(cls, upstream, issue, config):
-        """Helper function to create intermediary object."""
+        """Helper function to create an intermediary Issue object."""
         upstream_source = "github"
         comments = []
         for comment in issue["comments"]:
@@ -136,7 +136,7 @@ class Issue(object):
             reporter=issue["user"],
             assignee=issue["assignees"],
             status=issue["state"],
-            id=issue["id"],
+            id_=issue["id"],
             storypoints=issue.get("storypoints"),
             upstream_id=issue["number"],
             issue_type=issue_type,
@@ -163,7 +163,7 @@ class PR(object):
         reporter,
         assignee,
         status,
-        id,
+        id_,
         suffix,
         match,
         downstream=None,
@@ -196,7 +196,7 @@ class PR(object):
         self.reporter = reporter
         self.assignee = assignee
         self.status = status
-        self.id = str(id)
+        self.id = str(id_)
         self.suffix = suffix
         self.match = match
         # self.upstream_id = upstream_id
@@ -213,7 +213,7 @@ class PR(object):
 
     @classmethod
     def from_github(cls, upstream, pr, suffix, config):
-        """Helper function to create intermediary object."""
+        """Helper function to create an intermediary PR object."""
         # Set our upstream source
         upstream_source = "github"
 
@@ -264,7 +264,7 @@ class PR(object):
             assignee=pr["assignee"],
             # GitHub PRs do not have status
             status=None,
-            id=pr["number"],
+            id_=pr["number"],
             # upstream_id=issue['number'],
             suffix=suffix,
             match=match,
@@ -323,7 +323,7 @@ def matcher(content: Optional[str], comments: list[dict[str, str]]) -> str:
 
 def trim_string(content):
     """
-    Helper function to trim a string to ensure it is not over 50000 char
+    Helper function to trim a string to ensure it is not over 50,000 char
     Ref: https://github.com/release-engineering/Sync2Jira/issues/123
 
     :param String content: Comment content

--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -311,8 +311,10 @@ def handle_msg(body, suffix, config):
         # is actually for a PR
         if "pull_request" in body["issue"]:
             if body["action"] == "deleted":
-                # FIXME:  What _should_ we be doing in this case?  Calling pr_handlers[]()??
-                log.info("Not handling PR 'action' == 'deleted'")
+                # I think this gets triggered when someone deletes a comment
+                # from a PR.  Since we don't capture PR comments (only Issue
+                # comments), we don't need to react if one is deleted.
+                log.debug("Not handling PR 'action' == 'deleted'")
                 return
             # Handle this PR update as though it were an Issue, if that's
             # acceptable to the configuration.

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -167,7 +167,7 @@ def handle_github_message(body, config, is_pr=False):
                 )
                 return None
 
-    if is_pr and "closed_at" not in issue:
+    if is_pr and not issue.get("closed_at"):
         log.debug(
             "%r is a pull request.  Ignoring.", issue.get("html_url", "<missing URL>")
         )

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -576,13 +576,13 @@ class TestDownstreamIssue(unittest.TestCase):
         Tests 'test_get_preferred_issue_types' function
 
         Scenarios:
-         - upstream issue has a type
          - configuration has type mappings
             - first mapping matches
             - second mapping matches
             - multiple mappings match
             - no mapping matches
          - configuration has a default type
+         - upstream issue has a type
          - "RFE" in issue title
          - None of the above.
         """
@@ -603,15 +603,15 @@ class TestDownstreamIssue(unittest.TestCase):
 
         for scenario, expected in enumerate(
             (
-                ["GH_type"],  # 0: upstream issue has a type
-                ["mapped_type_C"],  # 1: first match in the configured type map
-                ["mapped_type_B"],  # 2: second match in the configured type map
+                ["mapped_type_C"],  # 0: first match in the configured type map
+                ["mapped_type_B"],  # 1: second match in the configured type map
                 [
                     "mapped_type_B",
                     "mapped_type_C",
-                ],  # 3: multiple matches in the configured type map
-                ["S2J_type"],  # 4: no matches in the configured type map
-                ["S2J_type"],  # 5: no type map; configuration has a default
+                ],  # 2: multiple matches in the configured type map
+                ["S2J_type"],  # 3: no matches in the configured type map
+                ["S2J_type"],  # 4: no type map; configuration has a default
+                ["GH_type"],  # 5: upstream issue has a type
                 ["Story"],  # 6: no configured default; "RFE" in issue title
                 ["Bug"],  # 7: default fallback
             )
@@ -621,17 +621,17 @@ class TestDownstreamIssue(unittest.TestCase):
 
             # Set up the next scenario
             if scenario == 0:
-                self.mock_issue.issue_type = None
-            elif scenario == 1:
                 self.mock_issue.tags = ["tag2"]
-            elif scenario == 2:
+            elif scenario == 1:
                 self.mock_issue.tags = ["tag2", "tag1"]
-            elif scenario == 3:
+            elif scenario == 2:
                 self.mock_issue.tags = ["fred"]
-            elif scenario == 4:
+            elif scenario == 3:
                 del conf["issue_types"]
-            elif scenario == 5:
+            elif scenario == 4:
                 del conf["type"]
+            elif scenario == 5:
+                self.mock_issue.issue_type = None
             elif scenario == 6:
                 self.mock_issue.title = "Plain Mock Issue Title"
             elif scenario == 7:

--- a/tests/test_intermediary.py
+++ b/tests/test_intermediary.py
@@ -41,6 +41,7 @@ class TestIntermediary(unittest.TestCase):
             "date_created": "mock_date",
             "number": "1",
             "storypoints": "mock_storypoints",
+            "type": None,
         }
 
         self.mock_github_pr = {
@@ -107,6 +108,7 @@ class TestIntermediary(unittest.TestCase):
         self.assertEqual(response.status, "Open")
         self.assertEqual(response.downstream, {"mock_downstream": "mock_key"})
         self.assertEqual(response.storypoints, "mock_storypoints")
+        self.assertEqual(response.issue_type, None)
 
     def test_from_github_open_without_priority(self):
         """
@@ -169,6 +171,30 @@ class TestIntermediary(unittest.TestCase):
         self.assertEqual(response.status, "Closed")
         self.assertEqual(response.downstream, {"mock_downstream": "mock_key"})
         self.assertEqual(response.storypoints, "mock_storypoints")
+
+    def test_from_github_with_type(self):
+        """
+        This tests the 'from_github' function under the Issue class with
+        various values in the 'type' field
+        """
+        for issue_type, expected in (
+            (None, None),
+            ({}, None),
+            ({"name": None}, None),
+            ({"name": "issue_type_name"}, "issue_type_name"),
+            ({"fred": 1}, None),
+        ):
+            # Set up return values
+            self.mock_github_issue["type"] = issue_type
+
+            # Call the function
+            response = i.Issue.from_github(
+                upstream="github", issue=self.mock_github_issue, config=self.mock_config
+            )
+
+            # Assert that we made the calls correctly
+            self.checkResponseFields(response)
+            self.assertEqual(expected, response.issue_type)
 
     def test_mapping_github(self):
         """


### PR DESCRIPTION
Currently, when _Sync2Jira_  creates a downstream issue, it determines the issue type using the following order of preference:
 - an issue type from the mapping in the configuration file (if present), selected based on the upstream "tags" (labels);
 - the default issue type configured for the project (if any);
 - `Story` if the issue title contains "RFE";
 - otherwise, `Bug`.

However, GitHub was recently enhanced to allow [Organizations to define "types"](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization) for upstream issues, providing a few types for use by default (`Task`, `Bug`, and `Feature`).

This PR changes the code such that, when _Sync2Jira_ creates a new Jira issue, the GH issue type, if set, will be the first preference.

_**Note:** the GH issue type **must** match one of the issue types provided by the downstream project's schema or the creation will fail and the issue will not be sync'd._

**Question for reviewers:**  Should the settings in the configuration file precede the upstream type in the order of preference?  If this PR is merged as is, there will be no way to handle the situation if the upstream Organization uses types which aren't available in the downstream project.  (Fortunately, the default GitHub types look like they all match Jira types, although I expect that `Feature` has very different semantics for most downstream projects.)

--------

In addition, this PR contains the following point changes/fixes:
- The code which adds a comment to the downstream issue noting the fact that there was more than one plausible issue type was throwing an exception owing to what amounts to a syntax error resulting from a botched edit (of mine...  😊  #254); the second commit fixes this, and the first includes a new unit test case for it.
- One of my changes from earlier this year (#282) identified a gap in the code where we were ignoring a certain type of FedMsg and added a log message for it.  I've since decided that we _should_ (explicitly) ignore this case, so I replaced the `FIXME` comment with an explanation and downgraded the log message from `INFO` to `DEBUG` level.
- In the common upstream issue processing path, we have a conditional which allows control to escape if the "issue" is actually a PR (and if the message is not indicating that the PR is now closed); I made the test slightly more robust (it will now properly handle the case of the key being present with an empty value).  
- I repositioned the log message which reports the inability to assign the downstream issue and made it conditional on there actually being someone to attempt to assign it to.  This should reduce the frequency of spurious occurrences in the log; therefore, I upgraded it from `INFO` to `WARNING` level.
- I reworked the body of `_get_preferred_issue_types()`, hopefully making it a little simpler and tighter.  I moved the inline code comments to the function docstring, and I added an exhaustive unit test for it.
- I modified the intermediary issue object to handle the GH issue type as an additional field.  I added the base case to an existing unit test as well as adding an additional unit test for the various possible cases.
- I refactored some duplicated code in the intermediary objects, moving it to a common function.
- I picked a bunch of lint that my IDE was flagging.

--------
Fixes #330.
Fixes DPROD-769.
cc: @gitdallas