### PR TITLE
Validate return from GitHub client `get_user()`

### DIFF
--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -327,7 +327,7 @@ def reformat_github_common(item, github_client):
     # Search for the user
     reporter = github_client.get_user(item["user"]["login"])
     # Update the reporter field in the message (to match Pagure format)
-    if reporter.name:
+    if reporter.name and reporter.name != "None":
         item["user"]["fullname"] = reporter.name
     else:
         item["user"]["fullname"] = item["user"]["login"]
@@ -336,7 +336,8 @@ def reformat_github_common(item, github_client):
     assignees = []
     for person in item.get("assignees", []):
         assignee = github_client.get_user(person["login"])
-        assignees.append({"fullname": assignee.name})
+        if assignee.name and assignee.name != "None":
+            assignees.append({"fullname": assignee.name})
     # Update the assignee field in the message (to match Pagure format)
     item["assignees"] = assignees
 


### PR DESCRIPTION
Since improving the logging, we're now seeing some messages like
```
Unable to assign RUN-3076 from upstream assignees [None] in https://github.com/containers/buildah/issues/6152
```
despite my attempts to suppress this message in cases where the issue is "unassignable".

Apparently (although, I have scant direct proof for this...), when the upstream user's profile doesn't include a publicly-available human-readable name (as is the case for the current assignee in https://github.com/containers/buildah/issues/6152), the GitHub client's `get_user()` function returns a value with `"None"` (not a value of `None`!) as the name.

So, this PR catches and ignores that value, which, in the case of the log message above, should result in an _empty_ list of assignees, which will in turn result in the message being suppressed.