### PR TITLE
Add latest pandoc to the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,13 @@ RUN mkdir -p /usr/local/src/sync2jira
 COPY . /usr/local/src/sync2jira
 
 # Install deps
-RUN pip install -r /usr/local/src/sync2jira/requirements.txt
+RUN pip3 install -r /usr/local/src/sync2jira/requirements.txt
+
+# Grab the latest pandoc binary
+RUN python3 -c 'from pathlib import Path; import pypandoc; from pypandoc.pandoc_download import download_pandoc; download_pandoc(targetfolder=Path(pypandoc.get_pandoc_path()).parent)'
 
 # Install Sync2Jira
-RUN  pip3 install --no-deps -v /usr/local/src/sync2jira
+RUN pip3 install --no-deps -v /usr/local/src/sync2jira
 
 USER 1001
 


### PR DESCRIPTION
This PR adds a tweak to the `Dockerfile` which, after it installs the Python requirements, including `pypandoc` and the `pandoc` binary, uses `pypandoc` to download the latest version of the `pandoc` binary, overwriting the one that was just installed with the Python package (which, at the moment, is `v3.6.1` while the latest is `v3.7.0.2`).

Hopefully, running the newer version of `pandoc` will address the `403/Access Denied` responses that we are occasionally getting from Jira when the upstream issue description contains particularly fancy formatting (like code blocks).

This change also contains two, hopefully cosmetic tweaks:  remove a spurious space, and consistently use `pip3` instead of using `pip` in one case.