### PR TITLE
Enable retry of Jira requests for PR syncing

### DIFF
--- a/tests/test_downstream_pr.py
+++ b/tests/test_downstream_pr.py
@@ -58,10 +58,7 @@ class TestDownstreamPR(unittest.TestCase):
 
     @mock.patch(PATH + "update_jira_issue")
     @mock.patch(PATH + "d_issue")
-    @mock.patch(PATH + "update_transition")
-    def test_sync_with_jira_link(
-        self, mock_update_transition, mock_d_issue, mock_update_jira_issue
-    ):
+    def test_sync_with_jira_link(self, mock_d_issue, mock_update_jira_issue):
         """
         This function tests 'sync_with_jira'
         """
@@ -77,16 +74,10 @@ class TestDownstreamPR(unittest.TestCase):
         )
         self.mock_client.search_issues.assert_called_with("Key = JIRA-1234")
         mock_d_issue.get_jira_client.assert_called_with(self.mock_pr, self.mock_config)
-        mock_update_transition.mock.asset_called_with(
-            self.mock_client, "mock_existing", self.mock_pr, "link_transition"
-        )
 
     @mock.patch(PATH + "update_jira_issue")
     @mock.patch(PATH + "d_issue")
-    @mock.patch(PATH + "update_transition")
-    def test_sync_with_jira_merged(
-        self, mock_update_transition, mock_d_issue, mock_update_jira_issue
-    ):
+    def test_sync_with_jira_merged(self, mock_d_issue, mock_update_jira_issue):
         """
         This function tests 'sync_with_jira'
         """
@@ -105,9 +96,6 @@ class TestDownstreamPR(unittest.TestCase):
         )
         mock_client.search_issues.assert_called_with("Key = JIRA-1234")
         mock_d_issue.get_jira_client.assert_called_with(self.mock_pr, self.mock_config)
-        mock_update_transition.mock.asset_called_with(
-            mock_client, "mock_existing", self.mock_pr, "merged_transition"
-        )
 
     @mock.patch(PATH + "update_jira_issue")
     @mock.patch(PATH + "d_issue")

--- a/tests/test_downstream_pr.py
+++ b/tests/test_downstream_pr.py
@@ -111,6 +111,24 @@ class TestDownstreamPR(unittest.TestCase):
 
     @mock.patch(PATH + "update_jira_issue")
     @mock.patch(PATH + "d_issue")
+    def test_sync_with_jira_no_match(self, mock_d_issue, mock_update_jira_issue):
+        """
+        This function tests 'sync_with_jira' when the PR contains no matched issue.
+        """
+        # Set up return values
+        mock_d_issue.get_jira_client.return_value = self.mock_client
+        self.mock_pr.jira_key = None
+
+        # Call the function
+        d.sync_with_jira(self.mock_pr, self.mock_config)
+
+        # Assert everything was called correctly
+        mock_d_issue.get_jira_client.assert_called_with(self.mock_pr, self.mock_config)
+        self.mock_client.search_issues.assert_not_called()
+        mock_update_jira_issue.assert_not_called()
+
+    @mock.patch(PATH + "update_jira_issue")
+    @mock.patch(PATH + "d_issue")
     def test_sync_with_jira_no_issues_found(self, mock_d_issue, mock_update_jira_issue):
         """
         This function tests 'sync_with_jira' where no issues are found


### PR DESCRIPTION
The logs recently held the following sequence:
```
[2025-08-06 09:03:30,377] INFO: Consuming message from topic org.fedoraproject.prod.github.pull_request (message id d68e7253-47e5-48c6-bf42-27f8672f00d5)
[2025-08-06 09:03:30,481] INFO: [PR] Considering upstream https://github.com/quipucords/quipucords-ui/pull/655, [quipucords/quipucords-ui] chore(release): 2.0.1
[2025-08-06 09:03:36,895] WARNING: No JIRA issue exists for PR: [quipucords/quipucords-ui] chore(release): 2.0.1. Query: Key = DISCOVERY-1054
[2025-08-06 09:03:36,896] INFO: Successfully consumed message from topic org.fedoraproject.prod.github.pull_request (message id d68e7253-47e5-48c6-bf42-27f8672f00d5)
```
However, contrary to the warning, the Jira issue, `DISCOVERY-1054`, _did_ exist at the time.  Instead, the request for it failed due (apparently) to one of our frequent, mysterious, transient Jira server errors.  And, the code involved caught and "handled" the error, rather than letting it propagate back to the logic which would have re-tried the request.

This PR removes the `try` block and the inappropriate error message.  Without it, the failure will be handled in the caller and retried and/or the actual Jira error will be logged.  The change also reworks the handling of the response, placing the success case first and splitting the failure cases.  It also downgrades the cases which are driven by the contents of the PR (as opposed to problems with the operation of Jira or the tool itself) from warnings to informational messages.  Finally, it adds an escape which skips the Jira request if we don't have an issue to request.

This pull request also includes a new unit test (so that rather than decreasing the coverage by 0.11% it _increases_ by 0.09% 🤪).  And, in the course of writing that, I stumbled upon a typo in a mock reference which (literally) does nothing, but, when you correct the typo, the test _fails_...so I removed the mock (and the incorrect and unneeded assertion).