### PR TITLE
Tweak Jira assignee matching

### DIFF
--- a/Rover_Lookup/tests/test_lookup.py
+++ b/Rover_Lookup/tests/test_lookup.py
@@ -170,7 +170,7 @@ class TestGithubUsernameToEmails:
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = False  # Search failed
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INFO):
             result = github_username_to_emails("test-user")
 
         assert result is None
@@ -269,6 +269,7 @@ class TestGithubUsernameToEmails:
             "cn=bind,dc=custom,dc=com",
             "secret",
             auto_bind=True,
+            raise_exceptions=True,
         )
 
         # Verify custom base DN was used in search

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -292,9 +292,13 @@ class TestDownstreamIssue(unittest.TestCase):
         # Set up return values
         mock_user = MagicMock()
         mock_user.displayName = "mock_assignee"
+        mock_user.name = "mock_assignee_n"
+        mock_user.emailAddress = "wrong_mock_user@redhat.com"
         mock_user.key = "mock_user_key"
         mock_user2 = MagicMock()
         mock_user2.displayName = "mock_assignee2"
+        mock_user2.name = "mock_assignee2_n"
+        mock_user.emailAddress = "mock_user@redhat.com"
         mock_user2.key = "mock_user_key2"
         mock_client.search_assignable_users_for_issues.return_value = [
             mock_user,


### PR DESCRIPTION
We're seeing some odd behavior for certain Issue assignees.  The Jira lookup based on the RH email address returned by the LDAP search is returning multiple assignees in these cases.  The `sync2jira` code then arbitrarily selects the first one, since they are all _supposed_ to match the email address.  But, the selected user doesn't actually match the upstream assignee, and it seems to be the same individual in all the cases...so, it looks like Jira is returning _all_ possible assignees -- not just the ones with matching email addresses -- and the list is probably in sorted order, and it results in a unique hit for all searches.

The principal purpose of this PR is to make two changes:  to enhance the logging so that we can get better insight into what's actually happening, and to provide some validation of the Jira response.

The code which matches the up- and downstream assignees is reordered slightly, so that it checks for a unique match before checking for multiple matches.  In the event that multiple possible assignees are returned, the code searches for one which matches the target email address.  Since all the returned assignees _should_ match the target, this code **should** simply select the first one; however, if Jira is misbehaving as I expect, this will ensure that we don't try to assign the downstream issue to a non-match.  This change also includes enhancements to the logging which, hopefully, will be illuminating.  And, because of this additional checking, we need additional support from the mocking in the unit tests.

In addition, this PR reworks the LDAP lookup's error handling, so that, hopefully, we'll be properly notified of real errors without false positives for "normal" cases (which will "quiet" the logging a bit).
  - The existing code conflates LDAP searches which "miss" (which produce no results) with requests that fail.  This change configures the LDAP client to report errors by exception.  Exceptions will be logged as `ERROR`'s; and, now, searches which are otherwise successful but which return no result will be logged as `INFO`'s.
  - The logging calls in the lookup code have been reworked to replace f-strings with format arguments, which allows the string formatting to be deferred and skipped altogether for logging which is disabled (such as `DEBUG`-level during production operation).
  - These changes require two tweaks to the unit tests, since they check the LDAP connection parameters and the log messages.