### PR TITLE
Add LDAP requirement to docs

### DIFF
--- a/docs/source/config-file.rst
+++ b/docs/source/config-file.rst
@@ -126,6 +126,9 @@ The config file is made up of multiple parts
         * Sync fixVersion (downstream milestone), do/don't overwrite downstream fixVersion
     * :code:`{'assignee': {'overwrite': True/False}}`
         * Sync assignee (for Github only the first assignee will sync) do/don't overwrite downstream assignee
+        * Note that the downstream assignee is selected by performing an LDAP query for the upstream user in the
+"Professional Social Media" link in the RoverPeople profiles, so, in order for this feature to work properly, each
+potential assignee needs to ensure that they have added their upstream identity(es) to their Rover profile.
     * :code:`'description'`
         * Sync description
     * :code:`'title'`


### PR DESCRIPTION
Reviewing [ANTSE-38](https://issues.redhat.com/browse/ANTSE-38) reminded me that #374 warrants a mention in the documentation...so, here it is.

Question for reviewers (beyond whether this change is sufficient...):  is there some other part of the docs which should also be updated?