### PR TITLE
Jira cache entries are strings, not lists

### DIFF
--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1420,12 +1420,12 @@ class TestDownstreamIssue(unittest.TestCase):
         d.jira_cache = d.UrlCache()  # Clear the cache
 
         # Call the function
-        response = d._matching_jira_issue_query(
+        response = d._get_existing_jira_issue(
             client=mock_client, issue=self.mock_issue, config=self.mock_config
         )
 
         # Assert everything was called correctly
-        self.assertEqual(response, [mock_downstream_issue])
+        self.assertEqual(response, mock_downstream_issue)
         mock_client.search_issues.assert_called_with("key in (SYNC2JIRA-123)")
         mock_check_comments_for_duplicates.assert_called_with(
             mock_client, mock_downstream_issue, "mock_username"


### PR DESCRIPTION
In #398, we ended up confused about what the entries in the `jira_cache` looked like.  This causes the code to fail with a `TypeError` (and so we avoid creating duplicate issues by dying instead!).  This PR reconciles the situation:  they are strings, not lists (of one string).

This PR corrects `_create_jira_issue()` to match the behavior of `_matching_jira_issue_query()`.

And, since we never are interested in a retrieving more than one issue, this PR also in-lines `_matching_jira_issue_query()` into `_get_existing_jira_issue()` to remove the extra, unneeded layer of call, changing the combined result to return a string (or `None`) instead of a list.

This PR also tweaks the one unit test to allow it to work.  I still need to add proper unit testing for the function which is now called `_get_existing_jira_issue()`, but the function is too complicated to test easily, so it needs to be refactored first, which I'll do in a separate PR.