### PR TITLE
If `create_pr_issue` is set, search before creating

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -294,7 +294,7 @@ def get_jira_client(issue, config):
     return client
 
 
-def _get_existing_jira_issue(client, issue, config):
+def get_existing_jira_issue(client, issue, config):
     """
     Get a jira issue by the linked remote issue.
 
@@ -1414,7 +1414,7 @@ def update_jira(client, config, issue):
     # First, check to see if we have a matching issue using the new method.
     # If we do, then bail out.  No sync needed.
     log.info("Looking for matching downstream issue via new method.")
-    existing = _get_existing_jira_issue(client, issue, config)
+    existing = get_existing_jira_issue(client, issue, config)
     if existing:
         # If we found an existing JIRA issue already
         log.info("Found existing, matching downstream %r.", existing.key)

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -222,9 +222,16 @@ def update_jira(client, config, pr):
         # add it.
         pr.jira_key = matcher(pr.content, pr.comments)
 
-    create_pr_issue = pr.downstream.get("create_pr_issue", False)
-    if not pr.jira_key and not create_pr_issue:
-        log.info("No JIRA key found in PR, skipping.")
+    if not pr.jira_key:
+        create_pr_issue = pr.downstream.get("create_pr_issue", False)
+        if create_pr_issue:
+            if existing := d_issue.get_existing_jira_issue(client, pr, config):
+                log.info(f"Found existing JIRA issue {existing.key} for PR {pr.url}")
+                update_jira_issue(existing, pr, client)
+            else:
+                _create_jira_issue_from_pr(client, pr, config)
+        else:
+            log.info("No JIRA key found in PR, skipping.")
         return
 
     response: ResultList[JIRAIssue] = client.search_issues(f"Key = {pr.jira_key}")
@@ -234,11 +241,7 @@ def update_jira(client, config, pr):
         update_jira_issue(response[0], pr, client)
         log.info(f"Done syncing PR {pr.url}")
     elif len(response) == 0:
-        if create_pr_issue:
-            # Convert PR to Issue-like object for creation
-            _create_jira_issue_from_pr(client, pr, config)
-        else:
-            log.info(f"No issue found for referenced key, {pr.jira_key}")
+        log.info(f"No issue found for referenced key, {pr.jira_key}")
     else:
         log.warning(
             f"Unexpectedly received {len(response)} matches for JIRA issue {pr.jira_key}"

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -191,7 +191,7 @@ class TestDownstreamIssue(unittest.TestCase):
     @mock.patch("jira.client.JIRA")
     def test_get_existing_newstyle(self, mock_client, mock_get_query, mock_filter):
         """
-        This tests '_get_existing_jira_issue' function.
+        This tests 'get_existing_jira_issue' function.
         """
         mock_issue_1: JIssue = MagicMock(spec=JIssue, name="mock_issue_1")
         mock_issue_1.key = "MOCK-1"
@@ -248,7 +248,7 @@ class TestDownstreamIssue(unittest.TestCase):
             mock_get_query.return_value = x["jira_results"]
             mock_client.search_issues.return_value = x["search_issues"]
             mock_filter.return_value = x["filter_results"]
-            result = d._get_existing_jira_issue(
+            result = d.get_existing_jira_issue(
                 client=mock_client, issue=self.mock_issue, config=self.mock_config
             )
             self.assertEqual(result, x["expected"])
@@ -893,7 +893,7 @@ class TestDownstreamIssue(unittest.TestCase):
             self.assertEqual(actual, expected, f"In scenario {scenario}")
 
     @mock.patch(PATH + "get_jira_client")
-    @mock.patch(PATH + "_get_existing_jira_issue")
+    @mock.patch(PATH + "get_existing_jira_issue")
     @mock.patch(PATH + "_update_jira_issue")
     @mock.patch(PATH + "_create_jira_issue")
     @mock.patch("jira.client.JIRA")
@@ -930,7 +930,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_existing_jira_issue_legacy.assert_not_called()
 
     @mock.patch(PATH + "get_jira_client")
-    @mock.patch(PATH + "_get_existing_jira_issue")
+    @mock.patch(PATH + "get_existing_jira_issue")
     @mock.patch(PATH + "_update_jira_issue")
     @mock.patch(PATH + "_create_jira_issue")
     @mock.patch("jira.client.JIRA")
@@ -965,7 +965,7 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_existing_jira_issue_legacy.assert_not_called()
 
     @mock.patch(PATH + "get_jira_client")
-    @mock.patch(PATH + "_get_existing_jira_issue")
+    @mock.patch(PATH + "get_existing_jira_issue")
     @mock.patch(PATH + "_update_jira_issue")
     @mock.patch(PATH + "_create_jira_issue")
     @mock.patch("jira.client.JIRA")


### PR DESCRIPTION
### **User description**
The recent support for creating downstream issues from upstream PRs always creates a new PR if it cannot find a reference to a downstream issue in the PR text.  It should instead check to see if it can find an existing, matching downstream issue before creating another one.  This PR effects that change.  In addition, it adds a number of unit tests to obtain near-full coverage of the `downstream_pr` `update_jira()`.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Refactor `update_jira()` to search for existing issues before creating new ones

- Move issue creation logic to execute only when search returns no results

- Add comprehensive unit tests covering all `update_jira()` code paths

- Improve test coverage for service unavailability and multiple issue scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR without JIRA key"] --> B{"create_pr_issue enabled?"}
  B -->|No| C["Skip processing"]
  B -->|Yes| D["Search for existing issue"]
  D --> E{"Issue found?"}
  E -->|Yes| F["Update existing issue"]
  E -->|No| G["Create new issue"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>downstream_pr.py</strong><dd><code>Defer issue creation until after search attempt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sync2jira/downstream_pr.py

<ul><li>Refactored logic to always attempt searching for issues when <br><code>create_pr_issue</code> is enabled<br> <li> Moved issue creation from early return path to execute only when <br>search returns zero results<br> <li> Changed early exit condition to skip processing only when both <br><code>jira_key</code> is missing AND <code>create_pr_issue</code> is disabled<br> <li> Preserved existing issue update and error handling for multiple <br>matches</ul>


</details>


  </td>
  <td><a href="https://github.com/release-engineering/Sync2Jira/pull/413/files#diff-6dea71a033b2b4311eb9fa1bcfd5ee2d726076b724a32faba18f3d8fa17e56fb">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_downstream_pr.py</strong><dd><code>Expand test coverage for all update_jira paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_downstream_pr.py

<ul><li>Added <code>test_update_jira_service_unavailable()</code> to verify RuntimeError on <br>service failure<br> <li> Replaced two old tests with five new comprehensive tests covering all <br><code>update_jira()</code> scenarios<br> <li> Added <code>test_update_jira_create_pr_issue_disabled_no_key()</code> for early <br>exit path<br> <li> Added <code>test_update_jira_with_key_found()</code> for successful issue update<br> <li> Added <code>test_update_jira_with_key_not_found_no_create()</code> for search miss <br>without creation<br> <li> Added <code>test_update_jira_with_key_not_found_create()</code> for search miss <br>with creation enabled<br> <li> Added <code>test_update_jira_multiple_issues()</code> for duplicate issue detection</ul>


</details>


  </td>
  <td><a href="https://github.com/release-engineering/Sync2Jira/pull/413/files#diff-ce2eacdda69e0b88a8fa6e6115ada00d464efbac6d66027c138d318148915a2f">+115/-23</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

