### PR TITLE
Handle failed Jira search (for archived issue)

### DIFF
--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -238,6 +238,13 @@ class TestDownstreamIssue(unittest.TestCase):
                 "expected": None,
             },
             {
+                "scenario": "Jira search returns no items",
+                "jira_results": "mock issue key query string",
+                "search_issues": ResultList[JIssue](()),
+                "filter_results": None,
+                "expected": None,
+            },
+            {
                 "scenario": "Jira search returns one item",
                 "jira_results": "mock issue key query string",
                 "search_issues": ResultList[JIssue]((mock_issue_1,)),


### PR DESCRIPTION
### **User description**
It is _possible_ that a downstream issue exists and we hit on its ID in our cache or in Snowflake but the subsequent Jira search for the issue object cannot find it.  This happens when the issue has been archived.  In the current code, we blunder on and eventually incur an `IndexError` exception.

This PR adds a check for the failed search which causes the function to return a "not found" response (which is accurate at least in terms of what Jira reported back).  I believe that this is preferable to aborting the update and producing a traceback in the log; however, it will presumably result in the tool creating a new instance of the downstream issue.

Presumably, the user does not want the downstream issue recreated.  However, `sync2jira` is involved, because the upstream issue is still active, and the user has not taken steps to stop it from being sync'd (e.g., by enabling filtering).  While we probably could modify the code locate the archived issue, the fact that it has been archived will probably prevent updates to it, and attempting to do so will probably create more disruption than we already have; and, adding handling specifically for archived issues seems inappropriate given that this situation is, at its root, one of the user's own creation.


___

### **PR Type**
Bug fix


___

### **Description**
- Handle failed Jira search when downstream issue archived

- Return graceful "not found" response instead of IndexError

- Add warning log when cached issue not found in Jira

- Add test case for empty search results scenario


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Jira search query"] --> B["Search returns empty results"]
  B --> C["Log warning message"]
  C --> D["Return None gracefully"]
  E["Previous behavior"] -.-> F["IndexError exception"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>downstream_issue.py</strong><dd><code>Add empty search results handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sync2jira/downstream_issue.py

<ul><li>Added check for empty search results after Jira query<br> <li> Returns None when downstream issue not found instead of proceeding<br> <li> Added warning log message with issue ID and URL details<br> <li> Handles archived issue scenario gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/release-engineering/Sync2Jira/pull/416/files#diff-6eddd439ea3637402e39f0c26091d6e31e9d056cc530ed26db3d413ed288c9f2">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_downstream_issue.py</strong><dd><code>Add test for empty search results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_downstream_issue.py

<ul><li>Added new test scenario for empty Jira search results<br> <li> Tests that function returns None when search returns no items<br> <li> Validates graceful handling of archived issue case</ul>


</details>


  </td>
  <td><a href="https://github.com/release-engineering/Sync2Jira/pull/416/files#diff-b2c0f23b6e1e250652284cfceedbdb02d7e8af1b0ba5bbb7f83d79bd56a61f0b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

