### PR TITLE
Support Single Select field mapping for storypoints

### DIFF
--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -317,7 +317,8 @@ def add_project_values(issue, upstream, headers, config):
                         issue["storypoints"] = int(sp_number)
                     except (ValueError, TypeError) as err:
                         log.info(
-                            "Error while processing storypoints for issue %s/%s#%s: %s",
+                            "Error converting Single Select storypoints value '%s' to int for issue %s/%s#%s: %s",
+                            sp_number,
                             orgname,
                             reponame,
                             issuenumber,
@@ -329,7 +330,8 @@ def add_project_values(issue, upstream, headers, config):
                     issue["storypoints"] = int(item["number"])
                 except (ValueError, TypeError, KeyError) as err:
                     log.info(
-                        "Error while processing storypoints for issue %s/%s#%s: %s",
+                        "Error converting Number field storypoints value '%s' to int for issue %s/%s#%s: %s",
+                        item.get("number", "missing"),
                         orgname,
                         reponame,
                         issuenumber,

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -292,7 +292,16 @@ def add_project_values(issue, upstream, headers, config):
         sp_field = github_project_fields.get("storypoints", {}).get("gh_field")
         if gh_field_name == sp_field:
             try:
-                issue["storypoints"] = int(item["number"])
+                # Check if there's an options mapping (for Single Select fields)
+                sp_options = github_project_fields.get("storypoints", {}).get("options")
+                if sp_options:
+                    # Single Select field - get name and map it
+                    sp_value = item.get("name")
+                    if sp_value and sp_value in sp_options:
+                        issue["storypoints"] = int(sp_options[sp_value])
+                else:
+                    # Number field - get number directly
+                    issue["storypoints"] = int(item["number"])
             except (ValueError, KeyError) as err:
                 log.info(
                     "Error while processing storypoints for issue %s/%s#%s: %s",

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -291,34 +291,50 @@ def add_project_values(issue, upstream, headers, config):
             continue
         sp_field = github_project_fields.get("storypoints", {}).get("gh_field")
         if gh_field_name == sp_field:
-            try:
-                # Check if there's an options mapping (for Single Select fields)
-                sp_options = github_project_fields.get("storypoints", {}).get("options")
-                if sp_options:
-                    # Single Select field - get name and map it
-                    sp_value = item.get("name")
-                    if sp_value and sp_value in sp_options:
-                        mapped_value = sp_options[sp_value]
-                        issue["storypoints"] = int(mapped_value)
-                    else:
+            # Check if there's an options mapping (for Single Select fields); if
+            # so, convert...
+            sp_options = github_project_fields.get("storypoints", {}).get("options")
+            if sp_options:
+                # Single Select field - get name and map it
+                sp_value = item.get("name")
+                if not sp_value:
+                    log.warning(
+                        "No Single Select name found for storypoints options in message for issue %s/%s#%s",
+                        orgname,
+                        reponame,
+                        issuenumber,
+                    )
+                elif (sp_number := sp_options.get(sp_value)) is None:
+                    log.info(
+                        "Storypoints value '%s' not found in options mapping for issue %s/%s#%s",
+                        sp_value,
+                        orgname,
+                        reponame,
+                        issuenumber,
+                    )
+                else:
+                    try:
+                        issue["storypoints"] = int(sp_number)
+                    except (ValueError, TypeError) as err:
                         log.info(
-                            "Storypoints value '%s' not found in options mapping for issue %s/%s#%s",
-                            sp_value,
+                            "Error while processing storypoints for issue %s/%s#%s: %s",
                             orgname,
                             reponame,
                             issuenumber,
+                            err,
                         )
-                else:
-                    # Number field - get number directly
+            else:
+                # Number field - get number directly
+                try:
                     issue["storypoints"] = int(item["number"])
-            except (ValueError, TypeError, KeyError) as err:
-                log.info(
-                    "Error while processing storypoints for issue %s/%s#%s: %s",
-                    orgname,
-                    reponame,
-                    issuenumber,
-                    err,
-                )
+                except (ValueError, TypeError, KeyError) as err:
+                    log.info(
+                        "Error while processing storypoints for issue %s/%s#%s: %s",
+                        orgname,
+                        reponame,
+                        issuenumber,
+                        err,
+                    )
             continue
 
 

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -289,12 +289,12 @@ def add_project_values(issue, upstream, headers, config):
         if gh_field_name == prio_field:
             issue["priority"] = item.get("name")
             continue
-        sp_field = github_project_fields.get("storypoints", {}).get("gh_field")
+        sp_dict = github_project_fields.get("storypoints", {})
+        sp_field = sp_dict.get("gh_field")
         if gh_field_name == sp_field:
             # Check if there's an options mapping (for Single Select fields); if
             # so, convert...
-            sp_options = github_project_fields.get("storypoints", {}).get("options")
-            if sp_options:
+            if sp_options := sp_dict.get("options"):
                 # Single Select field - get name and map it
                 sp_value = item.get("name")
                 if not sp_value:

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -298,11 +298,20 @@ def add_project_values(issue, upstream, headers, config):
                     # Single Select field - get name and map it
                     sp_value = item.get("name")
                     if sp_value and sp_value in sp_options:
-                        issue["storypoints"] = int(sp_options[sp_value])
+                        mapped_value = sp_options[sp_value]
+                        issue["storypoints"] = int(mapped_value)
+                    else:
+                        log.info(
+                            "Storypoints value '%s' not found in options mapping for issue %s/%s#%s",
+                            sp_value,
+                            orgname,
+                            reponame,
+                            issuenumber,
+                        )
                 else:
                     # Number field - get number directly
                     issue["storypoints"] = int(item["number"])
-            except (ValueError, KeyError) as err:
+            except (ValueError, TypeError, KeyError) as err:
                 log.info(
                     "Error while processing storypoints for issue %s/%s#%s: %s",
                     orgname,

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -768,6 +768,184 @@ class TestUpstreamIssue(unittest.TestCase):
             # Reset mock
             mock_requests_post.reset_mock()
 
+    @mock.patch(PATH + "requests.post")
+    def test_add_project_values_storypoints_error_handling(self, mock_requests_post):
+        """
+        Test 'add_project_values' error handling for storypoints conversion failures.
+        Tests both Single Select (Size) and Number (Estimate) field error paths.
+        """
+        # Set up base config
+        upstream_config = {
+            "issue_updates": ["github_project_fields"],
+            "github_project_number": 1,
+        }
+        self.mock_config["sync2jira"]["map"]["github"]["org/repo"] = upstream_config
+
+        mock_issue = {
+            "number": 1234,
+            "storypoints": None,
+            "priority": None,
+        }
+
+        # Test case 1: Single Select field (Size) with invalid mapped value (not convertible to int)
+        upstream_config["github_project_fields"] = {
+            "storypoints": {
+                "gh_field": "Size",
+                "options": {"Small": "not_a_number"},
+            }
+        }
+        mock_requests_post.return_value.json.return_value = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "project": {"title": "Project 1", "number": 1},
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "fieldName": {"name": "Size"},
+                                                "name": "Small",
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        u.add_project_values(
+            issue=mock_issue,
+            upstream="org/repo",
+            headers={},
+            config=self.mock_config,
+        )
+        # Storypoints should not be set due to conversion error
+        self.assertIsNone(mock_issue.get("storypoints"))
+        mock_requests_post.reset_mock()
+
+        # Test case 2: Number field (Estimate) with invalid number value
+        upstream_config["github_project_fields"] = {
+            "storypoints": {"gh_field": "Estimate"}
+        }
+        mock_requests_post.return_value.json.return_value = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "project": {"title": "Project 1", "number": 1},
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "fieldName": {"name": "Estimate"},
+                                                "number": "invalid",
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        mock_issue["storypoints"] = None
+        u.add_project_values(
+            issue=mock_issue,
+            upstream="org/repo",
+            headers={},
+            config=self.mock_config,
+        )
+        # Storypoints should not be set due to conversion error
+        self.assertIsNone(mock_issue.get("storypoints"))
+        mock_requests_post.reset_mock()
+
+        # Test case 3: Single Select field (Size) with missing name
+        upstream_config["github_project_fields"] = {
+            "storypoints": {
+                "gh_field": "Size",
+                "options": {"Small": 5},
+            }
+        }
+        mock_requests_post.return_value.json.return_value = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "project": {"title": "Project 1", "number": 1},
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "fieldName": {"name": "Size"},
+                                                # name is missing
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        mock_issue["storypoints"] = None
+        u.add_project_values(
+            issue=mock_issue,
+            upstream="org/repo",
+            headers={},
+            config=self.mock_config,
+        )
+        # Storypoints should not be set due to missing name
+        self.assertIsNone(mock_issue.get("storypoints"))
+        mock_requests_post.reset_mock()
+
+        # Test case 4: Single Select field (Size) with value not in options mapping
+        upstream_config["github_project_fields"] = {
+            "storypoints": {
+                "gh_field": "Size",
+                "options": {"Small": 5, "Medium": 8},
+            }
+        }
+        mock_requests_post.return_value.json.return_value = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "project": {"title": "Project 1", "number": 1},
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "fieldName": {"name": "Size"},
+                                                "name": "Large",  # Not in options
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        mock_issue["storypoints"] = None
+        u.add_project_values(
+            issue=mock_issue,
+            upstream="org/repo",
+            headers={},
+            config=self.mock_config,
+        )
+        # Storypoints should not be set due to unmapped value
+        self.assertIsNone(mock_issue.get("storypoints"))
+
     def test_passes_github_filters(self):
         """
         Test passes_github_filters for labels, milestone, and other fields.

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -769,10 +769,14 @@ class TestUpstreamIssue(unittest.TestCase):
             mock_requests_post.reset_mock()
 
     @mock.patch(PATH + "requests.post")
-    def test_add_project_values_storypoints_error_handling(self, mock_requests_post):
+    def test_add_project_values_storypoints(self, mock_requests_post):
         """
-        Test 'add_project_values' error handling for storypoints.
-        Table-driven test covering configuration errors and conversion failures.
+        Test 'add_project_values' storypoints processing.
+        Table-driven test covering both error paths and success paths.
+
+        Every scenario includes a Priority field as a canary: if the
+        function returns early (e.g. because of a missing status_code
+        mock), priority would not be set and the test would fail.
         """
         # Set up base config
         upstream_config = {
@@ -787,66 +791,179 @@ class TestUpstreamIssue(unittest.TestCase):
             "priority": None,
         }
 
-        # Test scenarios: (description, github_project_fields, field_values_nodes)
+        # Ensure the mock HTTP response indicates success so the function
+        # proceeds past the status_code check.
+        mock_requests_post.return_value.status_code = 200
+
+        # Each scenario: (description, github_project_fields,
+        #                  field_values_nodes, expected_storypoints)
+        # All scenarios include a Priority node so we can assert
+        # priority == "High" as proof we entered the field-processing loop.
         scenarios = (
-            # Test 1: No "storypoints" field in github_project_fields
+            # --- Error scenarios: storypoints should remain None ---
+            # Test 1: No "storypoints" key in github_project_fields
             (
                 "No storypoints in config",
                 {"priority": {"gh_field": "Priority"}},
-                [{"fieldName": {"name": "Size"}, "name": "Small"}],
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Size"}, "name": "Small"},
+                ],
+                None,
             ),
             # Test 2: No "gh_field" in storypoints config
             (
                 "No gh_field in storypoints",
-                {"storypoints": {"options": {"Small": 5}}},
-                [{"fieldName": {"name": "Size"}, "name": "Small"}],
+                {
+                    "priority": {"gh_field": "Priority"},
+                    "storypoints": {"options": {"Small": 5}},
+                },
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Size"}, "name": "Small"},
+                ],
+                None,
             ),
-            # Test 3: Empty options dict (Number field path with no value)
+            # Test 3: Empty options dict falls through to Number field path
             (
-                "Empty options dict",
-                {"storypoints": {"gh_field": "Size", "options": {}}},
-                [{"fieldName": {"name": "Size"}, "number": "invalid"}],
+                "Empty options dict with invalid number",
+                {
+                    "priority": {"gh_field": "Priority"},
+                    "storypoints": {"gh_field": "Size", "options": {}},
+                },
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Size"}, "number": "invalid"},
+                ],
+                None,
             ),
             # Test 4: Single Select - no "name" in item
             (
                 "Single Select missing name",
-                {"storypoints": {"gh_field": "Size", "options": {"Small": 5}}},
-                [{"fieldName": {"name": "Size"}}],
+                {
+                    "priority": {"gh_field": "Priority"},
+                    "storypoints": {
+                        "gh_field": "Size",
+                        "options": {"Small": 5},
+                    },
+                },
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Size"}},
+                ],
+                None,
             ),
             # Test 5: Single Select - value not in options mapping
             (
                 "Single Select unmapped value",
                 {
+                    "priority": {"gh_field": "Priority"},
                     "storypoints": {
                         "gh_field": "Size",
                         "options": {"Small": 5, "Medium": 8},
-                    }
+                    },
                 },
-                [{"fieldName": {"name": "Size"}, "name": "Large"}],
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Size"}, "name": "Large"},
+                ],
+                None,
             ),
             # Test 6: Single Select - ValueError converting mapped value
             (
                 "Single Select invalid mapped value",
                 {
+                    "priority": {"gh_field": "Priority"},
                     "storypoints": {
                         "gh_field": "Size",
                         "options": {"Small": "not_a_number"},
-                    }
+                    },
                 },
-                [{"fieldName": {"name": "Size"}, "name": "Small"}],
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Size"}, "name": "Small"},
+                ],
+                None,
             ),
             # Test 7: Number field - ValueError from invalid number
             (
                 "Number field invalid value",
-                {"storypoints": {"gh_field": "Estimate"}},
-                [{"fieldName": {"name": "Estimate"}, "number": "invalid"}],
+                {
+                    "priority": {"gh_field": "Priority"},
+                    "storypoints": {"gh_field": "Estimate"},
+                },
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Estimate"}, "number": "invalid"},
+                ],
+                None,
+            ),
+            # Test 8: Number field - KeyError from missing "number" key
+            (
+                "Number field missing number key",
+                {
+                    "priority": {"gh_field": "Priority"},
+                    "storypoints": {"gh_field": "Estimate"},
+                },
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Estimate"}},
+                ],
+                None,
+            ),
+            # --- Success scenarios: storypoints should be set ---
+            # Test 9: Single Select - valid mapping
+            (
+                "Single Select valid mapping",
+                {
+                    "priority": {"gh_field": "Priority"},
+                    "storypoints": {
+                        "gh_field": "Size",
+                        "options": {"Small": 1, "Medium": 3, "Large": 8},
+                    },
+                },
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Size"}, "name": "Medium"},
+                ],
+                3,
+            ),
+            # Test 10: Single Select - mapped value is a string int
+            (
+                "Single Select string mapped value",
+                {
+                    "priority": {"gh_field": "Priority"},
+                    "storypoints": {
+                        "gh_field": "Size",
+                        "options": {"Small": "2"},
+                    },
+                },
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Size"}, "name": "Small"},
+                ],
+                2,
+            ),
+            # Test 11: Number field - valid number
+            (
+                "Number field valid value",
+                {
+                    "priority": {"gh_field": "Priority"},
+                    "storypoints": {"gh_field": "Estimate"},
+                },
+                [
+                    {"fieldName": {"name": "Priority"}, "name": "High"},
+                    {"fieldName": {"name": "Estimate"}, "number": 5},
+                ],
+                5,
             ),
         )
 
-        for description, gpf, field_nodes in scenarios:
+        for description, gpf, field_nodes, expected_sp in scenarios:
             with self.subTest(description=description):
                 upstream_config["github_project_fields"] = gpf
                 mock_issue["storypoints"] = None
+                mock_issue["priority"] = None
 
                 mock_requests_post.return_value.json.return_value = {
                     "data": {
@@ -875,8 +992,21 @@ class TestUpstreamIssue(unittest.TestCase):
                     config=self.mock_config,
                 )
 
-                # Storypoints should not be set in any error scenario
-                self.assertIsNone(mock_issue.get("storypoints"))
+                # Priority must be set in every scenario — this is
+                # our canary that the function actually reached the
+                # field-processing loop rather than returning early.
+                self.assertEqual(
+                    mock_issue["priority"],
+                    "High",
+                    f"{description}: priority was not set — function "
+                    f"may have returned early",
+                )
+                self.assertEqual(
+                    mock_issue.get("storypoints"),
+                    expected_sp,
+                    f"{description}: expected storypoints={expected_sp}, "
+                    f"got {mock_issue.get('storypoints')}",
+                )
                 mock_requests_post.reset_mock()
 
     def test_passes_github_filters(self):

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -771,8 +771,8 @@ class TestUpstreamIssue(unittest.TestCase):
     @mock.patch(PATH + "requests.post")
     def test_add_project_values_storypoints_error_handling(self, mock_requests_post):
         """
-        Test 'add_project_values' error handling for storypoints conversion failures.
-        Tests both Single Select (Size) and Number (Estimate) field error paths.
+        Test 'add_project_values' error handling for storypoints.
+        Table-driven test covering configuration errors and conversion failures.
         """
         # Set up base config
         upstream_config = {
@@ -787,164 +787,84 @@ class TestUpstreamIssue(unittest.TestCase):
             "priority": None,
         }
 
-        # Test case 1: Single Select field (Size) with invalid mapped value (not convertible to int)
-        upstream_config["github_project_fields"] = {
-            "storypoints": {
-                "gh_field": "Size",
-                "options": {"Small": "not_a_number"},
-            }
-        }
-        mock_requests_post.return_value.json.return_value = {
-            "data": {
-                "repository": {
-                    "issue": {
-                        "projectItems": {
-                            "nodes": [
-                                {
-                                    "project": {"title": "Project 1", "number": 1},
-                                    "fieldValues": {
-                                        "nodes": [
-                                            {
-                                                "fieldName": {"name": "Size"},
-                                                "name": "Small",
-                                            }
-                                        ]
-                                    },
-                                }
-                            ]
-                        }
-                    }
-                }
-            }
-        }
-        u.add_project_values(
-            issue=mock_issue,
-            upstream="org/repo",
-            headers={},
-            config=self.mock_config,
+        # Test scenarios: (description, github_project_fields, field_values_nodes)
+        scenarios = (
+            # Test 1: No "storypoints" field in github_project_fields
+            (
+                "No storypoints in config",
+                {"priority": {"gh_field": "Priority"}},
+                [{"fieldName": {"name": "Size"}, "name": "Small"}],
+            ),
+            # Test 2: No "gh_field" in storypoints config
+            (
+                "No gh_field in storypoints",
+                {"storypoints": {"options": {"Small": 5}}},
+                [{"fieldName": {"name": "Size"}, "name": "Small"}],
+            ),
+            # Test 3: Empty options dict (Number field path with no value)
+            (
+                "Empty options dict",
+                {"storypoints": {"gh_field": "Size", "options": {}}},
+                [{"fieldName": {"name": "Size"}, "number": "invalid"}],
+            ),
+            # Test 4: Single Select - no "name" in item
+            (
+                "Single Select missing name",
+                {"storypoints": {"gh_field": "Size", "options": {"Small": 5}}},
+                [{"fieldName": {"name": "Size"}}],
+            ),
+            # Test 5: Single Select - value not in options mapping
+            (
+                "Single Select unmapped value",
+                {"storypoints": {"gh_field": "Size", "options": {"Small": 5, "Medium": 8}}},
+                [{"fieldName": {"name": "Size"}, "name": "Large"}],
+            ),
+            # Test 6: Single Select - ValueError converting mapped value
+            (
+                "Single Select invalid mapped value",
+                {"storypoints": {"gh_field": "Size", "options": {"Small": "not_a_number"}}},
+                [{"fieldName": {"name": "Size"}, "name": "Small"}],
+            ),
+            # Test 7: Number field - ValueError from invalid number
+            (
+                "Number field invalid value",
+                {"storypoints": {"gh_field": "Estimate"}},
+                [{"fieldName": {"name": "Estimate"}, "number": "invalid"}],
+            ),
         )
-        # Storypoints should not be set due to conversion error
-        self.assertIsNone(mock_issue.get("storypoints"))
-        mock_requests_post.reset_mock()
 
-        # Test case 2: Number field (Estimate) with invalid number value
-        upstream_config["github_project_fields"] = {
-            "storypoints": {"gh_field": "Estimate"}
-        }
-        mock_requests_post.return_value.json.return_value = {
-            "data": {
-                "repository": {
-                    "issue": {
-                        "projectItems": {
-                            "nodes": [
-                                {
-                                    "project": {"title": "Project 1", "number": 1},
-                                    "fieldValues": {
-                                        "nodes": [
-                                            {
-                                                "fieldName": {"name": "Estimate"},
-                                                "number": "invalid",
-                                            }
-                                        ]
-                                    },
-                                }
-                            ]
-                        }
-                    }
-                }
-            }
-        }
-        mock_issue["storypoints"] = None
-        u.add_project_values(
-            issue=mock_issue,
-            upstream="org/repo",
-            headers={},
-            config=self.mock_config,
-        )
-        # Storypoints should not be set due to conversion error
-        self.assertIsNone(mock_issue.get("storypoints"))
-        mock_requests_post.reset_mock()
+        for description, gpf, field_nodes in scenarios:
+            with self.subTest(description=description):
+                upstream_config["github_project_fields"] = gpf
+                mock_issue["storypoints"] = None
 
-        # Test case 3: Single Select field (Size) with missing name
-        upstream_config["github_project_fields"] = {
-            "storypoints": {
-                "gh_field": "Size",
-                "options": {"Small": 5},
-            }
-        }
-        mock_requests_post.return_value.json.return_value = {
-            "data": {
-                "repository": {
-                    "issue": {
-                        "projectItems": {
-                            "nodes": [
-                                {
-                                    "project": {"title": "Project 1", "number": 1},
-                                    "fieldValues": {
-                                        "nodes": [
-                                            {
-                                                "fieldName": {"name": "Size"},
-                                                # name is missing
-                                            }
-                                        ]
-                                    },
+                mock_requests_post.return_value.json.return_value = {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "projectItems": {
+                                    "nodes": [
+                                        {
+                                            "project": {"title": "Project 1", "number": 1},
+                                            "fieldValues": {"nodes": field_nodes},
+                                        }
+                                    ]
                                 }
-                            ]
+                            }
                         }
                     }
                 }
-            }
-        }
-        mock_issue["storypoints"] = None
-        u.add_project_values(
-            issue=mock_issue,
-            upstream="org/repo",
-            headers={},
-            config=self.mock_config,
-        )
-        # Storypoints should not be set due to missing name
-        self.assertIsNone(mock_issue.get("storypoints"))
-        mock_requests_post.reset_mock()
 
-        # Test case 4: Single Select field (Size) with value not in options mapping
-        upstream_config["github_project_fields"] = {
-            "storypoints": {
-                "gh_field": "Size",
-                "options": {"Small": 5, "Medium": 8},
-            }
-        }
-        mock_requests_post.return_value.json.return_value = {
-            "data": {
-                "repository": {
-                    "issue": {
-                        "projectItems": {
-                            "nodes": [
-                                {
-                                    "project": {"title": "Project 1", "number": 1},
-                                    "fieldValues": {
-                                        "nodes": [
-                                            {
-                                                "fieldName": {"name": "Size"},
-                                                "name": "Large",  # Not in options
-                                            }
-                                        ]
-                                    },
-                                }
-                            ]
-                        }
-                    }
-                }
-            }
-        }
-        mock_issue["storypoints"] = None
-        u.add_project_values(
-            issue=mock_issue,
-            upstream="org/repo",
-            headers={},
-            config=self.mock_config,
-        )
-        # Storypoints should not be set due to unmapped value
-        self.assertIsNone(mock_issue.get("storypoints"))
+                u.add_project_values(
+                    issue=mock_issue,
+                    upstream="org/repo",
+                    headers={},
+                    config=self.mock_config,
+                )
+
+                # Storypoints should not be set in any error scenario
+                self.assertIsNone(mock_issue.get("storypoints"))
+                mock_requests_post.reset_mock()
 
     def test_passes_github_filters(self):
         """

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -816,13 +816,23 @@ class TestUpstreamIssue(unittest.TestCase):
             # Test 5: Single Select - value not in options mapping
             (
                 "Single Select unmapped value",
-                {"storypoints": {"gh_field": "Size", "options": {"Small": 5, "Medium": 8}}},
+                {
+                    "storypoints": {
+                        "gh_field": "Size",
+                        "options": {"Small": 5, "Medium": 8},
+                    }
+                },
                 [{"fieldName": {"name": "Size"}, "name": "Large"}],
             ),
             # Test 6: Single Select - ValueError converting mapped value
             (
                 "Single Select invalid mapped value",
-                {"storypoints": {"gh_field": "Size", "options": {"Small": "not_a_number"}}},
+                {
+                    "storypoints": {
+                        "gh_field": "Size",
+                        "options": {"Small": "not_a_number"},
+                    }
+                },
                 [{"fieldName": {"name": "Size"}, "name": "Small"}],
             ),
             # Test 7: Number field - ValueError from invalid number
@@ -845,7 +855,10 @@ class TestUpstreamIssue(unittest.TestCase):
                                 "projectItems": {
                                     "nodes": [
                                         {
-                                            "project": {"title": "Project 1", "number": 1},
+                                            "project": {
+                                                "title": "Project 1",
+                                                "number": 1,
+                                            },
                                             "fieldValues": {"nodes": field_nodes},
                                         }
                                     ]


### PR DESCRIPTION
## Problem

When using GitHub Project **Single Select** fields with numeric option mappings for storypoints, sync2jira fails with:
```
Error while processing storypoints for issue: 'number'
```

This occurs because the code only supports **Number-type** fields and tries to read `item["number"]`, which doesn't exist for Single Select fields.

## Configuration Example

```python
github_project_fields={
    'storypoints': {
        'gh_field': 'Size',
        'options': {
            '🐇 Small': 5,
            '🐂 Medium': 8,
            '🦑 Large': 23,
        }
    }
}
```

## Solution

This PR adds support for Single Select fields with numeric mappings by:
1. Checking if the storypoints config has an `options` mapping
2. For Single Select fields: reading `item["name"]` and mapping it via the options dict
3. For Number fields: reading `item["number"]` directly (preserves existing behavior)
4. Ensuring the final value is always cast to `int` for Jira compatibility

## Testing

- Tested with migtools/crane repository using GitHub org-level project #24
- Single Select "Size" field with emoji options now correctly maps to numeric storypoints in Jira
- Existing Number-field configurations continue to work (backward compatible)

## Related

This enables configurations like those already used in other projects (packit, cpt, tmt, etc.) but with more flexible field types.