### PR TITLE
comment format payload limit fixes

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -256,42 +256,46 @@ def _comment_format(comment):
     )
 
 
-def _truncate_jira_text(body: str, upstream_issue_url: Optional[str] = None) -> str:
+def _truncate_jira_text(
+    body: str,
+    upstream_issue_url: Optional[str] = None,
+    max_chars: Optional[int] = None,
+) -> str:
     """
-    Ensure ``body`` fits Jira's comment size limit.
+    Ensure ``body`` fits within *max_chars* (default: comment limit).
 
     If truncated, a notice is prepended and a truncation marker appended.  When
     an upstream URL is available it is included — *unless* the link is so
     long that it would eat into the minimum body budget, in which case the link
     is dropped entirely.
     """
-    if len(body) <= JIRA_TEXT_BODY_MAX_CHARS:
+    if max_chars is None:
+        max_chars = JIRA_TEXT_BODY_MAX_CHARS
+
+    if len(body) <= max_chars:
         return body
 
     log.info(
-        "Truncating Jira comment body from %d to max %d characters",
+        "Truncating Jira text body from %d to max %d characters",
         len(body),
-        JIRA_TEXT_BODY_MAX_CHARS,
+        max_chars,
     )
 
     head = "{warning}*(Truncated.)*{warning}\n"
-    tail = "\n\n{warning}*....*{warning}"
+    tail = "\n\n{warning}*....*{warning}\n"
 
     link_block = ""
     if upstream_issue_url:
-        link_block = f"[See More|{upstream_issue_url}]\n\n"
+        link_block = f"[See More|{upstream_issue_url}]\n"
 
-    fixed_overhead = len(head) + len(tail)
+    fixed_overhead = len(head) + len(tail) + 1  # +1 for the \n before body
     link_overhead = 2 * len(link_block)
-    if (
-        fixed_overhead + link_overhead + JIRA_TEXT_BODY_MIN_CHARS
-        > JIRA_TEXT_BODY_MAX_CHARS
-    ):
+    if fixed_overhead + link_overhead + JIRA_TEXT_BODY_MIN_CHARS > max_chars:
         link_block = ""
         link_overhead = 0
 
-    core_len = JIRA_TEXT_BODY_MAX_CHARS - fixed_overhead - link_overhead
-    return head + link_block + body[:core_len] + tail + link_block
+    core_len = max_chars - fixed_overhead - link_overhead
+    return head + link_block + "\n" + body[:core_len] + tail + link_block
 
 
 def _comment_format_legacy(comment):
@@ -516,9 +520,7 @@ def check_comments_for_duplicate(client, result, username):
     return None
 
 
-def _find_comment_in_jira(
-    comment, j_comments, upstream_issue_url: Optional[str] = None
-):
+def _find_comment_in_jira(comment, j_comments, issue_url: Optional[str] = None):
     """
     Helper function to filter out comments that are matching.
 
@@ -533,9 +535,7 @@ def _find_comment_in_jira(
         # touch the comment; return the item as is.
         return comment
 
-    formatted_comment = _truncate_jira_text(
-        _comment_format(comment), upstream_issue_url
-    )
+    formatted_comment = _truncate_jira_text(_comment_format(comment), issue_url)
     legacy_formatted_comment = _comment_format_legacy(comment)
     for item in j_comments:
         if item.raw["body"] == legacy_formatted_comment:
@@ -1364,23 +1364,41 @@ def _update_tags(updates, existing, issue):
 
 
 def _build_description(issue):
-    # Build the description of the JIRA issue
+    # Build the description of the JIRA issue.
+    #
+    # Truncate issue.content *before* wrapping it with {quote} and the
+    # metadata prefix so the closing {quote} and decoration are never lost.
     issue_updates = issue.downstream.get("issue_updates", [])
-    description = ""
-    if "description" in issue_updates:
-        description = f"Upstream description: {{quote}}{issue.content}{{quote}}"
 
-    if issue.status and any("transition" in item for item in issue_updates):
-        # Add the upstream issue status to the top of the description
-        formatted_status = "Upstream issue status: " + issue.status
-        description = formatted_status + "\n" + description
-
+    # Build the prefix lines that will appear above the quoted content.
+    prefix_parts = []
     if issue.reporter:
-        # Add to the description
-        prefix = f"[{issue.id}] Upstream Reporter: {issue.reporter['fullname']}\n"
-        description = prefix + description
+        prefix_parts.append(
+            f"[{issue.id}] Upstream Reporter: {issue.reporter['fullname']}"
+        )
+    if issue.status and any("transition" in item for item in issue_updates):
+        prefix_parts.append("Upstream issue status: " + issue.status)
 
-    return _truncate_jira_text(description, getattr(issue, "url", None))
+    prefix = "\n".join(prefix_parts) + "\n" if prefix_parts else ""
+    suffix = ""
+    if "url" in issue_updates:
+        suffix = f"\nUpstream URL: {issue.url}"
+    if "description" in issue_updates:
+        quote_wrapper = "Upstream description: {quote}{quote}"
+        decoration_len = len(prefix) + len(quote_wrapper)
+        budget = JIRA_TEXT_BODY_MAX_CHARS - decoration_len
+        description = prefix
+        content = issue.content or ""
+        if len(content) > budget:
+            upstream_url = getattr(issue, "url", None)
+            content = _truncate_jira_text(content, upstream_url, max_chars=budget)
+            description += f"Upstream description: {{quote}}{content}{{quote}}"
+        else:
+            description += f"Upstream description: {{quote}}{content}{{quote}}" + suffix
+    else:
+        description = prefix + suffix
+
+    return description
 
 
 def _update_description(existing, issue):

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -46,6 +46,9 @@ load_dotenv()
 # This is used to ensure legacy comments are not touched
 UPDATE_DATE = datetime(2019, 7, 9, 18, 18, 36, 480291, tzinfo=timezone.utc)
 
+# Jira REST API rejects comment bodies longer than this (characters).
+JIRA_COMMENT_BODY_MAX_CHARS = 32767
+
 log = logging.getLogger("sync2jira")
 logging.getLogger("snowflake.connector").setLevel(logging.WARNING)
 
@@ -248,6 +251,52 @@ def _comment_format(comment):
         pretty_date,
         comment["body"],
     )
+
+
+def _truncate_jira_comment_body(
+    body: str, upstream_issue_url: Optional[str] = None
+) -> str:
+    """
+    Ensure ``body`` fits Jira's comment size limit.
+
+    If truncated, prepend a notice (and optional link to the upstream GitHub issue)
+    and append a marker so readers know where to find the full thread.
+    """
+    if len(body) <= JIRA_COMMENT_BODY_MAX_CHARS:
+        return body
+
+    log.info(
+        "Truncating Jira comment body from %d to max %d characters",
+        len(body),
+        JIRA_COMMENT_BODY_MAX_CHARS,
+    )
+
+    link_block = ""
+    if upstream_issue_url:
+        link_block = f"[View upstream issue on GitHub|{upstream_issue_url}]\n\n"
+
+    head = (
+        "{warning}*(This comment was truncated to fit Jira's "
+        f"{JIRA_COMMENT_BODY_MAX_CHARS}-character limit.)*{{warning}}\n\n" + link_block
+    )
+    tail = (
+        "\n\n{warning}*(Comment truncated"
+        + (
+            " — see GitHub link above for the full thread.)*"
+            if upstream_issue_url
+            else " — full thread not linked.)*"
+        )
+        + "{warning}"
+    )
+
+    budget = JIRA_COMMENT_BODY_MAX_CHARS - len(head) - len(tail)
+    if budget < 1:
+        head = "{warning}*(Truncated.)*{warning}\n"
+        tail = "\n{warning}*(…)*{warning}"
+        budget = JIRA_COMMENT_BODY_MAX_CHARS - len(head) - len(tail)
+
+    truncated_core = body[: max(budget, 0)]
+    return head + truncated_core + tail
 
 
 def _comment_format_legacy(comment):
@@ -472,12 +521,15 @@ def check_comments_for_duplicate(client, result, username):
     return None
 
 
-def _find_comment_in_jira(comment, j_comments):
+def _find_comment_in_jira(
+    comment, j_comments, upstream_issue_url: Optional[str] = None
+):
     """
     Helper function to filter out comments that are matching.
 
     :param Dict comment: Individual comment from upstream
     :param List j_comments: Comments from JIRA downstream
+    :param Optional[str] upstream_issue_url: Upstream issue URL for truncation notices
     :returns: Item/None
     :rtype: jira.resource.Comment/None
     """
@@ -486,7 +538,9 @@ def _find_comment_in_jira(comment, j_comments):
         # touch the comment; return the item as is.
         return comment
 
-    formatted_comment = _comment_format(comment)
+    formatted_comment = _truncate_jira_comment_body(
+        _comment_format(comment), upstream_issue_url
+    )
     legacy_formatted_comment = _comment_format_legacy(comment)
     for item in j_comments:
         if item.raw["body"] == legacy_formatted_comment:
@@ -505,18 +559,19 @@ def _find_comment_in_jira(comment, j_comments):
     return None
 
 
-def _comment_matching(g_comments, j_comments):
+def _comment_matching(g_comments, j_comments, upstream_issue_url: Optional[str] = None):
     """
     Function to filter out comments that are matching.
 
     :param List g_comments: Comments from Issue object
     :param List j_comments: Comments from JIRA downstream
+    :param Optional[str] upstream_issue_url: Upstream issue URL (for Jira truncation)
     :returns: Returns a list of comments that are not matching
     :rtype: List
     """
     return list(
         filter(
-            lambda x: _find_comment_in_jira(x, j_comments) is None
+            lambda x: _find_comment_in_jira(x, j_comments, upstream_issue_url) is None
             or x["changed"] is not None,
             g_comments,
         )
@@ -1066,11 +1121,11 @@ def _update_comments(client, existing, issue):
     # Get all existing comments
     comments = client.comments(existing)
     # Remove any comments that have already been added
-    comments_d = _comment_matching(issue.comments, comments)
+    comments_d = _comment_matching(issue.comments, comments, issue.url)
     # Loop through the comments that remain
     for comment in comments_d:
         # Format and add them
-        comment_body = _comment_format(comment)
+        comment_body = _truncate_jira_comment_body(_comment_format(comment), issue.url)
         client.add_comment(existing, comment_body)
     if len(comments_d) > 0:
         log.info("Comments synchronization done on %i comments.", len(comments_d))

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -47,7 +47,10 @@ load_dotenv()
 UPDATE_DATE = datetime(2019, 7, 9, 18, 18, 36, 480291, tzinfo=timezone.utc)
 
 # Jira REST API rejects comment bodies longer than this (characters).
-JIRA_COMMENT_BODY_MAX_CHARS = 32767
+JIRA_TEXT_BODY_MAX_CHARS = 32750
+# When truncating, keep at least this many characters of the original body.
+# If the hyperlink(s) wouldn't leave this much room, drop the hyperlink instead.
+JIRA_TEXT_BODY_MIN_CHARS = 1024
 
 log = logging.getLogger("sync2jira")
 logging.getLogger("snowflake.connector").setLevel(logging.WARNING)
@@ -253,50 +256,42 @@ def _comment_format(comment):
     )
 
 
-def _truncate_jira_comment_body(
-    body: str, upstream_issue_url: Optional[str] = None
-) -> str:
+def _truncate_jira_text(body: str, upstream_issue_url: Optional[str] = None) -> str:
     """
     Ensure ``body`` fits Jira's comment size limit.
 
-    If truncated, prepend a notice (and optional link to the upstream GitHub issue)
-    and append a marker so readers know where to find the full thread.
+    If truncated, a notice is prepended and a truncation marker appended.  When
+    an upstream URL is available it is included — *unless* the link is so
+    long that it would eat into the minimum body budget, in which case the link
+    is dropped entirely.
     """
-    if len(body) <= JIRA_COMMENT_BODY_MAX_CHARS:
+    if len(body) <= JIRA_TEXT_BODY_MAX_CHARS:
         return body
 
     log.info(
         "Truncating Jira comment body from %d to max %d characters",
         len(body),
-        JIRA_COMMENT_BODY_MAX_CHARS,
+        JIRA_TEXT_BODY_MAX_CHARS,
     )
+
+    head = "{warning}*(Truncated.)*{warning}\n"
+    tail = "\n\n{warning}*....*{warning}"
 
     link_block = ""
     if upstream_issue_url:
-        link_block = f"[View upstream issue on GitHub|{upstream_issue_url}]\n\n"
+        link_block = f"[See More|{upstream_issue_url}]\n\n"
 
-    head = (
-        "{warning}*(This comment was truncated to fit Jira's "
-        f"{JIRA_COMMENT_BODY_MAX_CHARS}-character limit.)*{{warning}}\n\n" + link_block
-    )
-    tail = (
-        "\n\n{warning}*(Comment truncated"
-        + (
-            " — see GitHub link above for the full thread.)*"
-            if upstream_issue_url
-            else " — full thread not linked.)*"
-        )
-        + "{warning}"
-    )
+    fixed_overhead = len(head) + len(tail)
+    link_overhead = 2 * len(link_block)
+    if (
+        fixed_overhead + link_overhead + JIRA_TEXT_BODY_MIN_CHARS
+        > JIRA_TEXT_BODY_MAX_CHARS
+    ):
+        link_block = ""
+        link_overhead = 0
 
-    budget = JIRA_COMMENT_BODY_MAX_CHARS - len(head) - len(tail)
-    if budget < 1:
-        head = "{warning}*(Truncated.)*{warning}\n"
-        tail = "\n{warning}*(…)*{warning}"
-        budget = JIRA_COMMENT_BODY_MAX_CHARS - len(head) - len(tail)
-
-    truncated_core = body[: max(budget, 0)]
-    return head + truncated_core + tail
+    core_len = JIRA_TEXT_BODY_MAX_CHARS - fixed_overhead - link_overhead
+    return head + link_block + body[:core_len] + tail + link_block
 
 
 def _comment_format_legacy(comment):
@@ -538,7 +533,7 @@ def _find_comment_in_jira(
         # touch the comment; return the item as is.
         return comment
 
-    formatted_comment = _truncate_jira_comment_body(
+    formatted_comment = _truncate_jira_text(
         _comment_format(comment), upstream_issue_url
     )
     legacy_formatted_comment = _comment_format_legacy(comment)
@@ -1125,7 +1120,7 @@ def _update_comments(client, existing, issue):
     # Loop through the comments that remain
     for comment in comments_d:
         # Format and add them
-        comment_body = _truncate_jira_comment_body(_comment_format(comment), issue.url)
+        comment_body = _truncate_jira_text(_comment_format(comment), issue.url)
         client.add_comment(existing, comment_body)
     if len(comments_d) > 0:
         log.info("Comments synchronization done on %i comments.", len(comments_d))
@@ -1385,11 +1380,7 @@ def _build_description(issue):
         prefix = f"[{issue.id}] Upstream Reporter: {issue.reporter['fullname']}\n"
         description = prefix + description
 
-    # Add the url if requested
-    if "url" in issue_updates:
-        description = description + f"\nUpstream URL: {issue.url}"
-
-    return description
+    return _truncate_jira_text(description, getattr(issue, "url", None))
 
 
 def _update_description(existing, issue):

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1313,7 +1313,7 @@ class TestDownstreamIssue(unittest.TestCase):
         # Assert all calls were made correctly
         mock_client.comments.assert_called_with(self.mock_downstream)
         mock_comment_matching.assert_called_with(
-            self.mock_issue.comments, "mock_comments"
+            self.mock_issue.comments, "mock_comments", self.mock_issue.url
         )
         mock_comment_format.assert_called_with("mock_comments_d")
         mock_client.add_comment.assert_called_with(
@@ -1729,6 +1729,29 @@ class TestDownstreamIssue(unittest.TestCase):
         self.assertIsNone(
             d._jira_user_display_label(types.SimpleNamespace()),
         )
+
+    def test_truncate_jira_comment_body_short_unchanged(self):
+        text = "short comment"
+        self.assertEqual(
+            d._truncate_jira_comment_body(text, "https://github.com/o/r/issues/1"),
+            text,
+        )
+
+    def test_truncate_jira_comment_body_long_with_issue_url(self):
+        issue_url = "https://github.com/o/r/issues/1"
+        body = "B" * (d.JIRA_COMMENT_BODY_MAX_CHARS + 500)
+        out = d._truncate_jira_comment_body(body, issue_url)
+        self.assertLessEqual(len(out), d.JIRA_COMMENT_BODY_MAX_CHARS)
+        self.assertIn("truncated to fit Jira's", out)
+        self.assertIn(f"[View upstream issue on GitHub|{issue_url}]", out)
+        self.assertIn("see GitHub link above for the full thread", out)
+        self.assertTrue(out.startswith("{warning}"))
+
+    def test_truncate_jira_comment_body_long_without_url(self):
+        body = "C" * (d.JIRA_COMMENT_BODY_MAX_CHARS + 100)
+        out = d._truncate_jira_comment_body(body, None)
+        self.assertLessEqual(len(out), d.JIRA_COMMENT_BODY_MAX_CHARS)
+        self.assertIn("full thread not linked", out)
 
     @mock.patch("jira.client.JIRA")
     def test_check_comments_for_duplicates(self, mock_client):

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1686,6 +1686,25 @@ class TestDownstreamIssue(unittest.TestCase):
             }
         )
 
+    def test_build_description_truncates_long_content(self):
+        """
+        When the assembled description exceeds the Jira limit,
+        _build_description should truncate via _truncate_jira_text.
+        """
+        issue = MagicMock()
+        issue.downstream = {
+            "issue_updates": ["description"],
+        }
+        issue.status = None
+        issue.reporter = None
+        issue.url = "https://github.com/org/repo/issues/42"
+        issue.content = "Z" * (d.JIRA_TEXT_BODY_MAX_CHARS + 5000)
+        result = d._build_description(issue)
+        self.assertLessEqual(len(result), d.JIRA_TEXT_BODY_MAX_CHARS)
+        self.assertIn("Upstream description:", result)
+        self.assertIn("Truncated", result)
+        self.assertGreaterEqual(result.count("Z"), d.JIRA_TEXT_BODY_MIN_CHARS)
+
     def test_verify_tags(self):
         """
         This function tests 'verify_tags' function
@@ -1730,40 +1749,44 @@ class TestDownstreamIssue(unittest.TestCase):
             d._jira_user_display_label(types.SimpleNamespace()),
         )
 
-    def test_truncate_jira_comment_body_short_unchanged(self):
+    def test_truncate_jira_text_short_unchanged(self):
         text = "short comment"
         self.assertEqual(
-            d._truncate_jira_comment_body(text, "https://github.com/o/r/issues/1"),
+            d._truncate_jira_text(text, "https://github.com/o/r/issues/1"),
             text,
         )
 
-    def test_truncate_jira_comment_body_long_with_issue_url(self):
+    def test_truncate_jira_text_long_with_issue_url(self):
         issue_url = "https://github.com/o/r/issues/1"
-        body = "B" * (d.JIRA_COMMENT_BODY_MAX_CHARS + 500)
-        out = d._truncate_jira_comment_body(body, issue_url)
-        self.assertLessEqual(len(out), d.JIRA_COMMENT_BODY_MAX_CHARS)
-        self.assertIn("truncated to fit Jira's", out)
-        self.assertIn(f"[View upstream issue on GitHub|{issue_url}]", out)
-        self.assertIn("see GitHub link above for the full thread", out)
+        body = "B" * (d.JIRA_TEXT_BODY_MAX_CHARS + 500)
+        out = d._truncate_jira_text(body, issue_url)
+        self.assertLessEqual(len(out), d.JIRA_TEXT_BODY_MAX_CHARS)
+        self.assertIn("Truncated", out)
+        link = f"[See More|{issue_url}]"
+        self.assertIn(link, out)
+        self.assertEqual(out.count(link), 2)
         self.assertTrue(out.startswith("{warning}"))
+        self.assertGreaterEqual(out.count("B"), d.JIRA_TEXT_BODY_MIN_CHARS)
 
-    def test_truncate_jira_comment_body_long_without_url(self):
-        body = "C" * (d.JIRA_COMMENT_BODY_MAX_CHARS + 100)
-        out = d._truncate_jira_comment_body(body, None)
-        self.assertLessEqual(len(out), d.JIRA_COMMENT_BODY_MAX_CHARS)
-        self.assertIn("full thread not linked", out)
+    def test_truncate_jira_text_long_without_url(self):
+        body = "C" * (d.JIRA_TEXT_BODY_MAX_CHARS + 100)
+        out = d._truncate_jira_text(body, None)
+        self.assertLessEqual(len(out), d.JIRA_TEXT_BODY_MAX_CHARS)
+        self.assertIn("....", out)
+        self.assertGreaterEqual(out.count("C"), d.JIRA_TEXT_BODY_MIN_CHARS)
 
-    def test_truncate_jira_comment_body_degenerate_head_tail_budget(self):
+    def test_truncate_jira_text_huge_url_drops_link(self):
         """
-        When the issue URL is huge, head+link can leave no room for body; cover
-        the minimal head/tail fallback (budget < 1 branch).
+        When the issue URL is so long that including it twice would leave less
+        than JIRA_TEXT_BODY_MIN_CHARS for the body, the link is dropped.
         """
         huge_url = "https://github.com/o/r/issues/1" + ("x" * 40000)
-        body = "D" * (d.JIRA_COMMENT_BODY_MAX_CHARS + 200)
-        out = d._truncate_jira_comment_body(body, huge_url)
-        self.assertLessEqual(len(out), d.JIRA_COMMENT_BODY_MAX_CHARS)
-        self.assertIn("*(Truncated.)*", out)
-        self.assertIn("*(…)*", out)
+        body = "D" * (d.JIRA_TEXT_BODY_MAX_CHARS + 200)
+        out = d._truncate_jira_text(body, huge_url)
+        self.assertLessEqual(len(out), d.JIRA_TEXT_BODY_MAX_CHARS)
+        self.assertNotIn(huge_url, out)
+        self.assertIn("....", out)
+        self.assertGreaterEqual(out.count("D"), d.JIRA_TEXT_BODY_MIN_CHARS)
 
     @mock.patch("jira.client.JIRA")
     def test_check_comments_for_duplicates(self, mock_client):

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1762,6 +1762,7 @@ class TestDownstreamIssue(unittest.TestCase):
         out = d._truncate_jira_text(body, issue_url)
         self.assertLessEqual(len(out), d.JIRA_TEXT_BODY_MAX_CHARS)
         self.assertIn("Truncated", out)
+        self.assertIn("....", out)
         link = f"[See More|{issue_url}]"
         self.assertIn(link, out)
         self.assertEqual(out.count(link), 2)
@@ -1772,7 +1773,10 @@ class TestDownstreamIssue(unittest.TestCase):
         body = "C" * (d.JIRA_TEXT_BODY_MAX_CHARS + 100)
         out = d._truncate_jira_text(body, None)
         self.assertLessEqual(len(out), d.JIRA_TEXT_BODY_MAX_CHARS)
+        self.assertIn("Truncated", out)
         self.assertIn("....", out)
+        self.assertNotIn("[See More|", out)
+        self.assertTrue(out.startswith("{warning}"))
         self.assertGreaterEqual(out.count("C"), d.JIRA_TEXT_BODY_MIN_CHARS)
 
     def test_truncate_jira_text_huge_url_drops_link(self):
@@ -1784,8 +1788,11 @@ class TestDownstreamIssue(unittest.TestCase):
         body = "D" * (d.JIRA_TEXT_BODY_MAX_CHARS + 200)
         out = d._truncate_jira_text(body, huge_url)
         self.assertLessEqual(len(out), d.JIRA_TEXT_BODY_MAX_CHARS)
-        self.assertNotIn(huge_url, out)
+        self.assertIn("Truncated", out)
         self.assertIn("....", out)
+        self.assertNotIn(huge_url, out)
+        self.assertNotIn("[See More|", out)
+        self.assertTrue(out.startswith("{warning}"))
         self.assertGreaterEqual(out.count("D"), d.JIRA_TEXT_BODY_MIN_CHARS)
 
     @mock.patch("jira.client.JIRA")

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1753,6 +1753,18 @@ class TestDownstreamIssue(unittest.TestCase):
         self.assertLessEqual(len(out), d.JIRA_COMMENT_BODY_MAX_CHARS)
         self.assertIn("full thread not linked", out)
 
+    def test_truncate_jira_comment_body_degenerate_head_tail_budget(self):
+        """
+        When the issue URL is huge, head+link can leave no room for body; cover
+        the minimal head/tail fallback (budget < 1 branch).
+        """
+        huge_url = "https://github.com/o/r/issues/1" + ("x" * 40000)
+        body = "D" * (d.JIRA_COMMENT_BODY_MAX_CHARS + 200)
+        out = d._truncate_jira_comment_body(body, huge_url)
+        self.assertLessEqual(len(out), d.JIRA_COMMENT_BODY_MAX_CHARS)
+        self.assertIn("*(Truncated.)*", out)
+        self.assertIn("*(…)*", out)
+
     @mock.patch("jira.client.JIRA")
     def test_check_comments_for_duplicates(self, mock_client):
         """


### PR DESCRIPTION
Changed the code if the comment payload limit exceeds 32767 characters than truncating the comment payload and adding the link of github issue url at the end.