### PR TITLE
LDAP IPA access

### DIFF
--- a/Rover_Lookup/lookup.py
+++ b/Rover_Lookup/lookup.py
@@ -45,13 +45,6 @@ def github_username_to_emails(
         logger.error("GitHub username cannot be empty")
         return None
 
-    # Default LDAP configuration for Red Hat Rover service
-    # FIXME:  These should be configured via config file.
-    if ldap_server is None:
-        ldap_server = "ldap://ldap.corp.redhat.com"  # Default Rover LDAP server
-    if ldap_base_dn is None:
-        ldap_base_dn = "ou=users,dc=redhat,dc=com"  # Default base DN
-
     # Construct the LDAP filter to match the GitHub "Professional Social Media" URL.
     # The rhatSocialURL field contains values like "Github->https://github.com/username".
     # However, 5% of the entries include a trailing slash (which GitHub accepts),

--- a/Rover_Lookup/tests/test_lookup.py
+++ b/Rover_Lookup/tests/test_lookup.py
@@ -50,13 +50,16 @@ class TestGithubUsernameToEmails:
     @patch("Rover_Lookup.lookup.Connection")
     def test_successful_lookup_single_record(self, mock_connection_class, caplog):
         """Test successful LDAP lookup with single record containing multiple emails."""
+        # Mock the LDAP server connection
         mock_conn = Mock()
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = True
 
+        # Mock the LDAP entry
         mock_entry = Mock()
         mock_entry.entry_dn = "cn=testuser,cn=users,cn=accounts,dc=redhat,dc=com"
 
+        # Mock email attributes
         mock_primary_mail = Mock()
         mock_primary_mail.value = "user@redhat.com"
         mock_entry.rhatPrimaryMail = mock_primary_mail
@@ -66,6 +69,7 @@ class TestGithubUsernameToEmails:
         mock_entry.mail = mock_mail
 
         mock_preferred_alias = Mock()
+        # Duplicate value to test deduplication
         mock_preferred_alias.value = "user@redhat.com"
         mock_entry.rhatPreferredAlias = mock_preferred_alias
 
@@ -74,12 +78,12 @@ class TestGithubUsernameToEmails:
         with caplog.at_level(logging.DEBUG):
             result = self._call("test-user")
 
+        # Verify result
         assert result == [
             "user.alias@redhat.com",
             "user@example.com",
             "user@redhat.com",
         ]
-
         mock_connection_class.assert_called_with(
             self.LDAP_SERVER,
             self.LDAP_BIND_DN,
@@ -88,6 +92,7 @@ class TestGithubUsernameToEmails:
             raise_exceptions=True,
         )
 
+        # Verify LDAP query was called correctly
         mock_conn.search.assert_called_once()
         search_args = mock_conn.search.call_args
         filter_part = "rhatSocialURL=Github->https://github.com/test-user"
@@ -103,10 +108,12 @@ class TestGithubUsernameToEmails:
     @patch("Rover_Lookup.lookup.Connection")
     def test_successful_lookup_multiple_records(self, mock_connection_class):
         """Test successful LDAP lookup with multiple records."""
+        # Mock the LDAP server connection
         mock_conn = Mock()
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = True
 
+        # Create two mock entries
         mock_entry1 = Mock()
         mock_entry1.entry_dn = "cn=user1,cn=users,cn=accounts,dc=redhat,dc=com"
         mock_primary_mail1 = Mock()
@@ -131,6 +138,7 @@ class TestGithubUsernameToEmails:
 
         result = self._call("test-user")
 
+        # Verify result combines emails from both records
         assert result == [
             "team@redhat.com",
             "user1@redhat.com",
@@ -144,7 +152,7 @@ class TestGithubUsernameToEmails:
         mock_conn = Mock()
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = True
-        mock_conn.entries = []
+        mock_conn.entries = []  # No entries found
 
         with caplog.at_level(logging.INFO):
             result = self._call("nonexistent-user")
@@ -160,9 +168,11 @@ class TestGithubUsernameToEmails:
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = True
 
+        # Mock entry with no email attributes
         mock_entry = Mock()
         mock_entry.entry_dn = "cn=testuser,cn=users,cn=accounts,dc=redhat,dc=com"
 
+        # Mock attributes that don't exist or are empty
         mock_entry.rhatPrimaryMail = Mock()
         mock_entry.rhatPrimaryMail.value = None
         mock_entry.mail = Mock()
@@ -181,7 +191,7 @@ class TestGithubUsernameToEmails:
         """Test LDAP search failure."""
         mock_conn = Mock()
         mock_connection_class.return_value = mock_conn
-        mock_conn.search.return_value = False
+        mock_conn.search.return_value = False  # Search failed
 
         with caplog.at_level(logging.INFO):
             result = self._call("test-user")
@@ -276,6 +286,7 @@ class TestGithubUsernameToEmails:
             ldap_password="secret",
         )
 
+        # Verify custom parameters were used
         mock_connection_class.assert_called_with(
             "ldap://custom.server.com",
             "cn=bind,dc=custom,dc=com",
@@ -284,6 +295,7 @@ class TestGithubUsernameToEmails:
             raise_exceptions=True,
         )
 
+        # Verify custom base DN was used in search
         search_args = mock_conn.search.call_args
         assert search_args[1]["search_base"] == "ou=people,dc=custom,dc=com"
 

--- a/Rover_Lookup/tests/test_lookup.py
+++ b/Rover_Lookup/tests/test_lookup.py
@@ -15,6 +15,22 @@ from Rover_Lookup import github_username_to_emails
 class TestGithubUsernameToEmails:
     """Test cases for the github_username_to_emails function."""
 
+    LDAP_SERVER = "ldaps://ipa.redhat.com"
+    LDAP_BASE_DN = "cn=users,cn=accounts,dc=redhat,dc=com"
+    LDAP_BIND_DN = "uid=sync2jira,cn=users,cn=accounts,dc=redhat,dc=com"
+    LDAP_PASSWORD = "test-password"
+
+    def _call(self, username, **overrides):
+        """Helper to call github_username_to_emails with IPA defaults."""
+        kwargs = dict(
+            ldap_server=self.LDAP_SERVER,
+            ldap_base_dn=self.LDAP_BASE_DN,
+            ldap_bind_dn=self.LDAP_BIND_DN,
+            ldap_password=self.LDAP_PASSWORD,
+        )
+        kwargs.update(overrides)
+        return github_username_to_emails(username, **kwargs)
+
     def test_empty_username_returns_none(self, caplog):
         """Test that empty username returns None and logs error."""
         with caplog.at_level(logging.ERROR):
@@ -34,16 +50,13 @@ class TestGithubUsernameToEmails:
     @patch("Rover_Lookup.lookup.Connection")
     def test_successful_lookup_single_record(self, mock_connection_class, caplog):
         """Test successful LDAP lookup with single record containing multiple emails."""
-        # Mock the LDAP server connection
         mock_conn = Mock()
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = True
 
-        # Mock LDAP entry with email attributes
         mock_entry = Mock()
-        mock_entry.entry_dn = "cn=testuser,ou=users,dc=redhat,dc=com"
+        mock_entry.entry_dn = "cn=testuser,cn=users,cn=accounts,dc=redhat,dc=com"
 
-        # Mock email attributes
         mock_primary_mail = Mock()
         mock_primary_mail.value = "user@redhat.com"
         mock_entry.rhatPrimaryMail = mock_primary_mail
@@ -53,28 +66,34 @@ class TestGithubUsernameToEmails:
         mock_entry.mail = mock_mail
 
         mock_preferred_alias = Mock()
-        # Duplicate value to test deduplication
         mock_preferred_alias.value = "user@redhat.com"
         mock_entry.rhatPreferredAlias = mock_preferred_alias
 
         mock_conn.entries = [mock_entry]
 
         with caplog.at_level(logging.DEBUG):
-            result = github_username_to_emails("test-user")
+            result = self._call("test-user")
 
-        # Verify result
         assert result == [
             "user.alias@redhat.com",
             "user@example.com",
             "user@redhat.com",
         ]
 
-        # Verify LDAP query was called correctly
+        mock_connection_class.assert_called_with(
+            self.LDAP_SERVER,
+            self.LDAP_BIND_DN,
+            self.LDAP_PASSWORD,
+            auto_bind=True,
+            raise_exceptions=True,
+        )
+
         mock_conn.search.assert_called_once()
         search_args = mock_conn.search.call_args
         filter_part = "rhatSocialURL=Github->https://github.com/test-user"
         expected_filter = f"(|({filter_part})({filter_part}/))"
         assert search_args[1]["search_filter"] == expected_filter
+        assert search_args[1]["search_base"] == self.LDAP_BASE_DN
         assert "rhatPrimaryMail" in search_args[1]["attributes"]
         assert "mail" in search_args[1]["attributes"]
         assert "rhatPreferredAlias" in search_args[1]["attributes"]
@@ -84,14 +103,12 @@ class TestGithubUsernameToEmails:
     @patch("Rover_Lookup.lookup.Connection")
     def test_successful_lookup_multiple_records(self, mock_connection_class):
         """Test successful LDAP lookup with multiple records."""
-        # Mock the LDAP server connection
         mock_conn = Mock()
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = True
 
-        # Create two mock entries
         mock_entry1 = Mock()
-        mock_entry1.entry_dn = "cn=user1,ou=users,dc=redhat,dc=com"
+        mock_entry1.entry_dn = "cn=user1,cn=users,cn=accounts,dc=redhat,dc=com"
         mock_primary_mail1 = Mock()
         mock_primary_mail1.value = "user1@redhat.com"
         mock_entry1.rhatPrimaryMail = mock_primary_mail1
@@ -101,7 +118,7 @@ class TestGithubUsernameToEmails:
         mock_entry1.rhatPreferredAlias.value = "team@redhat.com"
 
         mock_entry2 = Mock()
-        mock_entry2.entry_dn = "cn=user2,ou=users,dc=redhat,dc=com"
+        mock_entry2.entry_dn = "cn=user2,cn=users,cn=accounts,dc=redhat,dc=com"
         mock_primary_mail2 = Mock()
         mock_primary_mail2.value = "user2@redhat.com"
         mock_entry2.rhatPrimaryMail = mock_primary_mail2
@@ -112,9 +129,8 @@ class TestGithubUsernameToEmails:
 
         mock_conn.entries = [mock_entry1, mock_entry2]
 
-        result = github_username_to_emails("test-user")
+        result = self._call("test-user")
 
-        # Verify result combines emails from both records
         assert result == [
             "team@redhat.com",
             "user1@redhat.com",
@@ -128,10 +144,10 @@ class TestGithubUsernameToEmails:
         mock_conn = Mock()
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = True
-        mock_conn.entries = []  # No entries found
+        mock_conn.entries = []
 
         with caplog.at_level(logging.INFO):
-            result = github_username_to_emails("nonexistent-user")
+            result = self._call("nonexistent-user")
 
         assert result == []
         assert "No LDAP entries found" in caplog.text
@@ -144,11 +160,9 @@ class TestGithubUsernameToEmails:
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = True
 
-        # Mock entry with no email attributes
         mock_entry = Mock()
-        mock_entry.entry_dn = "cn=testuser,ou=users,dc=redhat,dc=com"
+        mock_entry.entry_dn = "cn=testuser,cn=users,cn=accounts,dc=redhat,dc=com"
 
-        # Mock attributes that don't exist or are empty
         mock_entry.rhatPrimaryMail = Mock()
         mock_entry.rhatPrimaryMail.value = None
         mock_entry.mail = Mock()
@@ -158,7 +172,7 @@ class TestGithubUsernameToEmails:
 
         mock_conn.entries = [mock_entry]
 
-        result = github_username_to_emails("test-user")
+        result = self._call("test-user")
 
         assert result == []
 
@@ -167,10 +181,10 @@ class TestGithubUsernameToEmails:
         """Test LDAP search failure."""
         mock_conn = Mock()
         mock_connection_class.return_value = mock_conn
-        mock_conn.search.return_value = False  # Search failed
+        mock_conn.search.return_value = False
 
         with caplog.at_level(logging.INFO):
-            result = github_username_to_emails("test-user")
+            result = self._call("test-user")
 
         assert result is None
         assert "LDAP search failed" in caplog.text
@@ -184,7 +198,7 @@ class TestGithubUsernameToEmails:
         mock_connection_class.side_effect = LDAPException("Connection refused")
 
         with caplog.at_level(logging.ERROR):
-            result = github_username_to_emails("test-user")
+            result = self._call("test-user")
 
         assert result is None
         assert "Error connecting to LDAP server" in caplog.text
@@ -192,13 +206,13 @@ class TestGithubUsernameToEmails:
 
     @patch("Rover_Lookup.lookup.Connection")
     def test_connection_ldap_vpn_exception(self, mock_connection_class, caplog):
-        """Test LDAP exception handling."""
+        """Test LDAP exception with VPN hint for redhat.com servers."""
         from Rover_Lookup.lookup import LDAPException
 
         mock_connection_class.side_effect = LDAPException("invalid server address")
 
         with caplog.at_level(logging.ERROR):
-            result = github_username_to_emails("test-user")
+            result = self._call("test-user")
 
         assert result is None
         assert "Error connecting to LDAP server" in caplog.text
@@ -210,7 +224,7 @@ class TestGithubUsernameToEmails:
         mock_connection_class.side_effect = ValueError("An error occurred")
 
         with caplog.at_level(logging.ERROR):
-            result = github_username_to_emails("test-user")
+            result = self._call("test-user")
 
         assert result is None
         assert "Unexpected error connecting to LDAP server" in caplog.text
@@ -226,7 +240,7 @@ class TestGithubUsernameToEmails:
         mock_conn.search.side_effect = LDAPException("Connection failed")
 
         with caplog.at_level(logging.ERROR):
-            result = github_username_to_emails("test-user")
+            result = self._call("test-user")
 
         assert result is None
         assert "LDAP error while looking up" in caplog.text
@@ -240,7 +254,7 @@ class TestGithubUsernameToEmails:
         mock_conn.search.side_effect = ValueError("An error occurred")
 
         with caplog.at_level(logging.ERROR):
-            result = github_username_to_emails("test-user")
+            result = self._call("test-user")
 
         assert result is None
         assert "Unexpected error while looking up" in caplog.text
@@ -248,13 +262,13 @@ class TestGithubUsernameToEmails:
 
     @patch("Rover_Lookup.lookup.Connection")
     def test_custom_ldap_parameters(self, mock_connection_class):
-        """Test function with custom LDAP parameters."""
+        """Test function with custom LDAP parameters overriding defaults."""
         mock_conn = Mock()
         mock_connection_class.return_value = mock_conn
         mock_conn.search.return_value = True
         mock_conn.entries = []
 
-        result = github_username_to_emails(
+        result = self._call(
             "test-user",
             ldap_server="ldap://custom.server.com",
             ldap_base_dn="ou=people,dc=custom,dc=com",
@@ -262,7 +276,6 @@ class TestGithubUsernameToEmails:
             ldap_password="secret",
         )
 
-        # Verify custom parameters were used
         mock_connection_class.assert_called_with(
             "ldap://custom.server.com",
             "cn=bind,dc=custom,dc=com",
@@ -271,7 +284,6 @@ class TestGithubUsernameToEmails:
             raise_exceptions=True,
         )
 
-        # Verify custom base DN was used in search
         search_args = mock_conn.search.call_args
         assert search_args[1]["search_base"] == "ou=people,dc=custom,dc=com"
 

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -711,7 +711,13 @@ def assign_user(
 
     # See if any of the upstream assignees has a downstream email address.
     for assignee in issue.assignee:
-        emails = Rover_Lookup.github_username_to_emails(assignee["login"])
+        emails = Rover_Lookup.github_username_to_emails(
+            assignee["login"],
+            ldap_server=os.getenv("LDAP_SERVER"),
+            ldap_base_dn=os.getenv("LDAP_BASE_DN"),
+            ldap_bind_dn=os.getenv("LDAP_BIND_DN"),
+            ldap_password=os.getenv("LDAP_PASSWORD"),
+        )
         if not emails:
             continue
 

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -618,7 +618,7 @@ class TestDownstreamIssue(unittest.TestCase):
             "login4": [mock_user.emailAddress],
             "login5": [mock_user2.emailAddress],
         }
-        mock_rover_lookup.side_effect = lambda un: rlu.get(
+        mock_rover_lookup.side_effect = lambda un, **kwargs: rlu.get(
             un, AssertionError("Test bug!  Missing assignee login")
         )
 


### PR DESCRIPTION
Removed anoymous access of LDAP made the service account mandatory to access the LDAP service and also removed default hardcoded server name and bind_dn we can pass it through the config which is better and secure.