### PR TITLE
pypandoc tex format fix

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1521,6 +1521,29 @@ def sync_with_jira(issue, config):
         retry = True
 
 
+def convert_content(content):
+    """Convert GitHub Flavored Markdown to Jira format via pypandoc.
+
+    Falls back to disabling TeX math extensions if the initial conversion
+    fails (e.g. content misinterpreted as LaTeX).  Returns the original
+    content unchanged if both attempts fail.
+    """
+    try:
+        content = pypandoc.convert_text(content, "jira", format="gfm")
+    except Exception as e:
+        log.warning("pypandoc conversion failed, retrying with TeX disabled: %s", e)
+        try:
+            sanitized = content.replace("\\", "\\\\").replace("$", "\\$")
+            content = pypandoc.convert_text(
+                sanitized,
+                "jira",
+                format="gfm-tex_math_dollars-tex_math_single_backslash",
+            )
+        except Exception as e2:
+            log.warning("pypandoc fallback also failed; using raw content: %s", e2)
+    return content
+
+
 def update_jira(client, config, issue):
     # Check the status of the JIRA client
     if not config["sync2jira"]["develop"] and not check_jira_status(client):
@@ -1533,25 +1556,7 @@ def update_jira(client, config, issue):
             and issue.content
             and "github_markdown" in issue.downstream["issue_updates"]
         ):
-            try:
-                issue.content = pypandoc.convert_text(
-                    issue.content, "jira", format="gfm"
-                )
-            except Exception as e:
-                log.warning(
-                    "pypandoc conversion failed, retrying with TeX disabled: %s", e
-                )
-                try:
-                    sanitized = issue.content.replace("\\", "\\\\").replace("$", r"\$")
-                    issue.content = pypandoc.convert_text(
-                        sanitized,
-                        "jira",
-                        format="gfm-tex_math_dollars-tex_math_single_backslash",
-                    )
-                except Exception as e2:
-                    log.warning(
-                        "pypandoc fallback also failed; using raw content: %s", e2
-                    )
+            issue.content = convert_content(issue.content)
     # First, check to see if we have a matching issue using the new method.
     # If we do, then bail out.  No sync needed.
     log.info("Looking for matching downstream issue via new method.")

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1533,8 +1533,19 @@ def update_jira(client, config, issue):
             and issue.content
             and "github_markdown" in issue.downstream["issue_updates"]
         ):
-            issue.content = pypandoc.convert_text(issue.content, "jira", format="gfm")
-
+            try:
+                issue.content = pypandoc.convert_text(issue.content, "jira", format="gfm")
+            except Exception as e:
+                log.warning("pypandoc conversion failed, retrying with TeX disabled: %s", e)
+                try:
+                    sanitized = issue.content.replace("\\", "\\\\").replace("$", r"\$")
+                    issue.content = pypandoc.convert_text(
+                        sanitized,
+                        "jira",
+                        format="gfm-tex_math_dollars-tex_math_single_backslash",
+                    )
+                except Exception as e2:
+                    log.warning("pypandoc fallback also failed; using raw content: %s", e2)
     # First, check to see if we have a matching issue using the new method.
     # If we do, then bail out.  No sync needed.
     log.info("Looking for matching downstream issue via new method.")

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1534,9 +1534,13 @@ def update_jira(client, config, issue):
             and "github_markdown" in issue.downstream["issue_updates"]
         ):
             try:
-                issue.content = pypandoc.convert_text(issue.content, "jira", format="gfm")
+                issue.content = pypandoc.convert_text(
+                    issue.content, "jira", format="gfm"
+                )
             except Exception as e:
-                log.warning("pypandoc conversion failed, retrying with TeX disabled: %s", e)
+                log.warning(
+                    "pypandoc conversion failed, retrying with TeX disabled: %s", e
+                )
                 try:
                     sanitized = issue.content.replace("\\", "\\\\").replace("$", r"\$")
                     issue.content = pypandoc.convert_text(
@@ -1545,7 +1549,9 @@ def update_jira(client, config, issue):
                         format="gfm-tex_math_dollars-tex_math_single_backslash",
                     )
                 except Exception as e2:
-                    log.warning("pypandoc fallback also failed; using raw content: %s", e2)
+                    log.warning(
+                        "pypandoc fallback also failed; using raw content: %s", e2
+                    )
     # First, check to see if we have a matching issue using the new method.
     # If we do, then bail out.  No sync needed.
     log.info("Looking for matching downstream issue via new method.")

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1521,12 +1521,16 @@ def sync_with_jira(issue, config):
         retry = True
 
 
-def convert_content(content):
+def convert_content(content: str) -> str:
     """Convert GitHub Flavored Markdown to Jira format via pypandoc.
 
     Falls back to disabling TeX math extensions if the initial conversion
     fails (e.g. content misinterpreted as LaTeX).  Returns the original
     content unchanged if both attempts fail.
+
+    :param str content: GitHub Flavored Markdown text
+    :returns: Jira-formatted text, or the original content on failure
+    :rtype: str
     """
     try:
         content = pypandoc.convert_text(content, "jira", format="gfm")
@@ -1557,6 +1561,7 @@ def update_jira(client, config, issue):
             and "github_markdown" in issue.downstream["issue_updates"]
         ):
             issue.content = convert_content(issue.content)
+
     # First, check to see if we have a matching issue using the new method.
     # If we do, then bail out.  No sync needed.
     log.info("Looking for matching downstream issue via new method.")

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -23,7 +23,6 @@ import logging
 from jira import JIRAError
 from jira.client import Issue as JIRAIssue
 from jira.client import ResultList
-import pypandoc
 
 # Local Modules
 import sync2jira.downstream_issue as d_issue
@@ -266,7 +265,7 @@ def _create_jira_issue_from_pr(client, pr, config):
             and pr_content
             and "github_markdown" in pr.downstream["issue_updates"]
         ):
-            pr_content = pypandoc.convert_text(pr_content, "jira", format="gfm")
+            pr_content = d_issue.convert_content(pr_content)
 
     # Convert PR to Issue-like object for creation
     # PR and Issue share similar structure, but we need to adapt it

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1110,72 +1110,48 @@ class TestDownstreamIssue(unittest.TestCase):
         )
         mock_existing_jira_issue_legacy.assert_not_called()
 
-    @mock.patch(PATH + "get_jira_client")
-    @mock.patch(PATH + "get_existing_jira_issue")
-    @mock.patch(PATH + "_update_jira_issue")
-    @mock.patch(PATH + "_create_jira_issue")
-    @mock.patch("jira.client.JIRA")
-    @mock.patch(PATH + "check_jira_status")
     @mock.patch(PATH + "pypandoc")
-    def test_pypandoc_conversion_scenarios(
-        self,
-        mock_pypandoc,
-        mock_check_jira_status,
-        mock_client,
-        mock_create_jira_issue,
-        mock_update_jira_issue,
-        mock_existing_jira_issue,
-        mock_get_jira_client,
-    ):
-        """Test pypandoc conversion: normal success, TeX fallback, and double failure."""
-        mock_get_jira_client.return_value = mock_client
-        mock_existing_jira_issue.return_value = self.mock_downstream
-        mock_check_jira_status.return_value = True
+    def test_convert_content(self, mock_pypandoc):
+        """convert_content(): normal success, TeX fallback, and double failure."""
+        # Case 1: Normal GFM conversion succeeds
+        mock_pypandoc.convert_text.return_value = "normal markdown"
 
-        self.mock_issue.source = "github"
-        self.mock_issue.downstream["issue_updates"].append("github_markdown")
-
-        # --- Case 1: Normal conversion succeeds ---
-        mock_pypandoc.convert_text.reset_mock()
-        mock_pypandoc.convert_text.return_value = "converted"
-        self.mock_issue.content = "normal markdown"
-
-        d.sync_with_jira(issue=self.mock_issue, config=self.mock_config)
+        result = d.convert_content("normal markdown")
 
         mock_pypandoc.convert_text.assert_called_once_with(
             "normal markdown", "jira", format="gfm"
         )
-        self.assertEqual(self.mock_issue.content, "converted")
+        self.assertEqual(result, "normal markdown")
 
-        # --- Case 2: First call fails (TeX error), fallback succeeds ---
+        # Case 2: First call fails (TeX error), fallback succeeds
         mock_pypandoc.convert_text.reset_mock()
         mock_pypandoc.convert_text.side_effect = [
             RuntimeError("Error producing PDF"),
             "fallback converted",
         ]
-        self.mock_issue.content = "bad $tex"
 
-        d.sync_with_jira(issue=self.mock_issue, config=self.mock_config)
+        result = d.convert_content("bad $tex")
 
         self.assertEqual(mock_pypandoc.convert_text.call_count, 2)
+        first_call = mock_pypandoc.convert_text.call_args_list[0]
+        self.assertEqual(first_call[1]["format"], "gfm")
+
         fallback_call = mock_pypandoc.convert_text.call_args_list[1]
         self.assertEqual(
             fallback_call[1]["format"],
             "gfm-tex_math_dollars-tex_math_single_backslash",
         )
-        self.assertEqual(self.mock_issue.content, "fallback converted")
+        self.assertEqual(fallback_call[0][0], "bad \\$tex")
+        self.assertEqual(result, "fallback converted")
 
-        # --- Case 3: Both calls fail, raw content preserved ---
+        # Case 3: Both calls fail, raw content preserved
         mock_pypandoc.convert_text.reset_mock()
         mock_pypandoc.convert_text.side_effect = RuntimeError("pandoc broken")
-        self.mock_issue.content = "raw content"
 
-        d.sync_with_jira(issue=self.mock_issue, config=self.mock_config)
+        result = d.convert_content("raw content")
 
-        self.assertEqual(self.mock_issue.content, "raw content")
-
-        # In all three cases, sync should have continued
-        self.assertEqual(mock_update_jira_issue.call_count, 3)
+        self.assertEqual(mock_pypandoc.convert_text.call_count, 2)
+        self.assertEqual(result, "raw content")
 
     @mock.patch(PATH + "_update_title")
     @mock.patch(PATH + "_update_description")

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1110,6 +1110,73 @@ class TestDownstreamIssue(unittest.TestCase):
         )
         mock_existing_jira_issue_legacy.assert_not_called()
 
+    @mock.patch(PATH + "get_jira_client")
+    @mock.patch(PATH + "get_existing_jira_issue")
+    @mock.patch(PATH + "_update_jira_issue")
+    @mock.patch(PATH + "_create_jira_issue")
+    @mock.patch("jira.client.JIRA")
+    @mock.patch(PATH + "check_jira_status")
+    @mock.patch(PATH + "pypandoc")
+    def test_pypandoc_conversion_scenarios(
+        self,
+        mock_pypandoc,
+        mock_check_jira_status,
+        mock_client,
+        mock_create_jira_issue,
+        mock_update_jira_issue,
+        mock_existing_jira_issue,
+        mock_get_jira_client,
+    ):
+        """Test pypandoc conversion: normal success, TeX fallback, and double failure."""
+        mock_get_jira_client.return_value = mock_client
+        mock_existing_jira_issue.return_value = self.mock_downstream
+        mock_check_jira_status.return_value = True
+
+        self.mock_issue.source = "github"
+        self.mock_issue.downstream["issue_updates"].append("github_markdown")
+
+        # --- Case 1: Normal conversion succeeds ---
+        mock_pypandoc.convert_text.reset_mock()
+        mock_pypandoc.convert_text.return_value = "converted"
+        self.mock_issue.content = "normal markdown"
+
+        d.sync_with_jira(issue=self.mock_issue, config=self.mock_config)
+
+        mock_pypandoc.convert_text.assert_called_once_with(
+            "normal markdown", "jira", format="gfm"
+        )
+        self.assertEqual(self.mock_issue.content, "converted")
+
+        # --- Case 2: First call fails (TeX error), fallback succeeds ---
+        mock_pypandoc.convert_text.reset_mock()
+        mock_pypandoc.convert_text.side_effect = [
+            RuntimeError("Error producing PDF"),
+            "fallback converted",
+        ]
+        self.mock_issue.content = "bad $tex"
+
+        d.sync_with_jira(issue=self.mock_issue, config=self.mock_config)
+
+        self.assertEqual(mock_pypandoc.convert_text.call_count, 2)
+        fallback_call = mock_pypandoc.convert_text.call_args_list[1]
+        self.assertEqual(
+            fallback_call[1]["format"],
+            "gfm-tex_math_dollars-tex_math_single_backslash",
+        )
+        self.assertEqual(self.mock_issue.content, "fallback converted")
+
+        # --- Case 3: Both calls fail, raw content preserved ---
+        mock_pypandoc.convert_text.reset_mock()
+        mock_pypandoc.convert_text.side_effect = RuntimeError("pandoc broken")
+        self.mock_issue.content = "raw content"
+
+        d.sync_with_jira(issue=self.mock_issue, config=self.mock_config)
+
+        self.assertEqual(self.mock_issue.content, "raw content")
+
+        # In all three cases, sync should have continued
+        self.assertEqual(mock_update_jira_issue.call_count, 3)
+
     @mock.patch(PATH + "_update_title")
     @mock.patch(PATH + "_update_description")
     @mock.patch(PATH + "_update_comments")


### PR DESCRIPTION
If the `pypandoc` `convert` function fails due to TeX formatting issues, wrap the call in a `try` block. In the `except` block, clean or sanitize the TeX content and then retry the conversion.
