### PR TITLE
handling PR updates

### DIFF
--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -311,9 +311,9 @@ def handle_msg(body, suffix, config):
         # is actually for a PR
         if "pull_request" in body["issue"]:
             if body["action"] == "deleted":
-                # I think this gets triggered when someone deletes a comment
-                # from a PR.  Since we don't capture PR comments (only Issue
-                # comments), we don't need to react if one is deleted.
+                # Triggered when someone deletes a comment from a PR.
+                # We sync PR comments but do not propagate deletions to
+                # Jira, so there is nothing to do here.
                 log.debug("Not handling PR 'action' == 'deleted'")
                 return
             # Handle this PR update as though it were an Issue, if that's

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -205,11 +205,13 @@ def handle_github_message(body, config, is_pr=False):
     upstream = "{owner}/{repo}".format(owner=owner, repo=repo)
 
     issue = body["issue"]
-    if not passes_github_filters(issue, config, upstream, item_type="issue"):
-        return None
-    if is_pr and not issue.get("closed_at"):
+    item_type = "PR" if is_pr else "issue"
+    if not passes_github_filters(issue, config, upstream, item_type=item_type):
         log.debug(
-            "%r is a pull request.  Ignoring.", issue.get("html_url", "<missing URL>")
+            "%s %s %s does not pass filters",
+            item_type,
+            upstream,
+            issue.get("html_url", "<missing URL>"),
         )
         return None
 

--- a/sync2jira/upstream_issue.py
+++ b/sync2jira/upstream_issue.py
@@ -208,10 +208,10 @@ def handle_github_message(body, config, is_pr=False):
     item_type = "PR" if is_pr else "issue"
     if not passes_github_filters(issue, config, upstream, item_type=item_type):
         log.debug(
-            "%s %s %s does not pass filters",
+            "%s %s#%s does not pass filters",
             item_type,
             upstream,
-            issue.get("html_url", "<missing URL>"),
+            issue.get("number", "?"),
         )
         return None
 

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -502,21 +502,23 @@ class TestUpstreamIssue(unittest.TestCase):
 
     @mock.patch(PATH + "Github")
     @mock.patch("sync2jira.intermediary.Issue.from_github")
-    def test_handle_github_message_pull_request(
+    def test_handle_github_message_pull_request_not_in_sync(
         self, mock_issue_from_github, mock_github
     ):
         """
-        This function tests 'handle_github_message' the issue is a pull request comment
+        Test that handle_github_message returns None when is_pr=True but
+        the repo's sync list does not include 'pullrequest'.  This exercises
+        the passes_github_filters gate that guards the PR path.
         """
-        # Set up return values
-        self.mock_github_message_body["issue"] = {"pull_request": "test"}
+        # Repo only syncs issues, not pull requests
+        self.mock_config["sync2jira"]["map"]["github"]["org/repo"]["sync"] = ["issue"]
 
-        # Call the function
+        # Call the function with is_pr=True (simulating a github.issue_comment on a PR)
         response = u.handle_github_message(
-            body=self.mock_github_message_body, config=self.mock_config
+            body=self.mock_github_message_body, config=self.mock_config, is_pr=True
         )
 
-        # Assert that all calls were made correctly
+        # passes_github_filters rejects it before reaching Github/Issue.from_github
         mock_issue_from_github.assert_not_called()
         mock_github.assert_not_called()
         self.assertEqual(None, response)

--- a/tests/test_upstream_issue.py
+++ b/tests/test_upstream_issue.py
@@ -1180,6 +1180,58 @@ class TestUpstreamIssue(unittest.TestCase):
                 )
                 mock_requests_post.reset_mock()
 
+    def test_passes_github_filters_routing(self):
+        """
+        Test passes_github_filters routing guards:
+        - upstream not in map → None
+        - item_type not in sync list → None
+        - item_type="PR" with pullrequest in sync → proceeds to filter evaluation
+        """
+        upstream = "org/repo"
+        good_item = {
+            "labels": [{"name": "custom_tag"}],
+            "milestone": {"number": 1},
+            "filter1": "filter1",
+        }
+
+        # upstream not in mapped_repos → None
+        self.assertIsNone(
+            u.passes_github_filters(
+                good_item, self.mock_config, "other/repo", item_type="issue"
+            )
+        )
+
+        # item_type="issue" but sync only contains "pullrequest" → None
+        self.mock_config["sync2jira"]["map"]["github"][upstream]["sync"] = [
+            "pullrequest"
+        ]
+        self.assertIsNone(
+            u.passes_github_filters(
+                good_item, self.mock_config, upstream, item_type="issue"
+            )
+        )
+
+        # item_type="PR" but sync only contains "issue" → None
+        self.mock_config["sync2jira"]["map"]["github"][upstream]["sync"] = ["issue"]
+        self.assertIsNone(
+            u.passes_github_filters(
+                good_item, self.mock_config, upstream, item_type="PR"
+            )
+        )
+
+        # item_type="PR" with pullrequest in sync and all filters pass → True
+        self.mock_config["sync2jira"]["map"]["github"][upstream]["sync"] = [
+            "pullrequest"
+        ]
+        self.mock_config["sync2jira"]["filters"]["github"][upstream] = {
+            "labels": ["custom_tag"]
+        }
+        self.assertTrue(
+            u.passes_github_filters(
+                good_item, self.mock_config, upstream, item_type="PR"
+            )
+        )
+
     def test_passes_github_filters(self):
         """
         Test passes_github_filters for labels, milestone, and other fields.
@@ -1265,6 +1317,23 @@ class TestUpstreamIssue(unittest.TestCase):
             "milestone": {"number": 999},
             "filter1": "filter1",
         }
+        self.assertTrue(
+            u.passes_github_filters(item, self.mock_config, upstream, item_type="issue")
+        )
+        # Test 8: milestone filter configured; item has milestone key but value is None → False
+        # (exercises the `or {}` defensive branch in the milestone handler)
+        self.mock_config["sync2jira"]["filters"]["github"][upstream] = {"milestone": 1}
+        item = {
+            "labels": [{"name": "custom_tag"}],
+            "milestone": None,
+            "filter1": "filter1",
+        }
+        self.assertFalse(
+            u.passes_github_filters(item, self.mock_config, upstream, item_type="issue")
+        )
+        # No filters at all → True (nothing to reject)
+        self.mock_config["sync2jira"]["filters"]["github"][upstream] = {}
+        item = {"labels": [], "milestone": None, "filter1": "anything"}
         self.assertTrue(
             u.passes_github_filters(item, self.mock_config, upstream, item_type="issue")
         )


### PR DESCRIPTION
Handling the PR comment updates coming through github.issue_comments topic. Initially it checked in upstream_issue handler that if the its PR and if its not closed than it would ignore the PR events now removed the check so it will sync the comments from PR coming through issue handler and also in checking the github passes filter passing correct item type..
