### PR TITLE
comment limit fix

### DIFF
--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -52,6 +52,7 @@ JIRA_TEXT_BODY_MAX_CHARS = 32750
 # If the hyperlink(s) wouldn't leave this much room, drop the hyperlink instead.
 JIRA_TEXT_BODY_MIN_CHARS = 1024
 
+PAGE_SIZE = 100
 log = logging.getLogger("sync2jira")
 logging.getLogger("snowflake.connector").setLevel(logging.WARNING)
 
@@ -511,19 +512,18 @@ def check_comments_for_duplicate(client, result, username):
     :returns: duplicate JIRA issue or None
     :rtype: jira.resource.Issue or None
     """
-    page_size = 100
     start = 0
     while True:
-        batch = client.comments(result, start_at=start, max_results=page_size)
+        batch = client.comments(result, start_at=start, max_results=PAGE_SIZE)
         for comment in batch:
             search = re.search(r"Marking as duplicate of (\w*)-(\d*)", comment.body)
             author_label = _jira_user_display_label(comment.author)
             if search and author_label == username:
                 issue_id = search.groups()[0] + "-" + search.groups()[1]
                 return client.issue(issue_id)
-        if len(batch) < page_size:
+        if len(batch) < PAGE_SIZE:
             break  # last page; duplicate marker not found
-        start += page_size
+        start += PAGE_SIZE
     return None
 
 
@@ -1165,18 +1165,17 @@ def _update_comments(client, existing, issue):
     :param sync2jira.intermediary.Issue issue: Upstream issue
     :returns: Nothing
     """
-    page_size = 100
     start = 0
     # All upstream comments that still need to be checked / added
     pending = list(issue.comments)
 
     while pending:
-        batch = client.comments(existing, start_at=start, max_results=page_size)
+        batch = client.comments(existing, start_at=start, max_results=PAGE_SIZE)
         # Remove upstream comments already present in this page of Jira comments
         pending = _comment_matching(pending, batch, issue.url)
-        if len(batch) < page_size:
+        if len(batch) < PAGE_SIZE:
             break  # last page reached; no more Jira comments to check
-        start += page_size
+        start += PAGE_SIZE
 
     for comment in pending:
         comment_body = _truncate_jira_text(_comment_format(comment), issue.url)

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1142,6 +1142,32 @@ def _update_title(issue, existing):
     log.info("Updated title")
 
 
+def _get_all_comments(client, issue):
+    """
+    Fetch every comment on a JIRA issue, handling pagination transparently.
+
+    ``client.comments()`` returns at most ``max_results`` entries per call
+    (Jira Cloud defaults to 100).  Iterating in fixed-size pages until a
+    short page is received guarantees we collect all comments regardless of
+    how many there are.
+
+    :param jira.client.JIRA client: JIRA client
+    :param jira.resources.Issue issue: Downstream JIRA issue
+    :returns: All comments on the issue
+    :rtype: list[jira.resources.Comment]
+    """
+    page_size = 100
+    all_comments = []
+    start = 0
+    while True:
+        batch = client.comments(issue, start_at=start, max_results=page_size)
+        all_comments.extend(batch)
+        if len(batch) < page_size:
+            break
+        start += page_size
+    return all_comments
+
+
 def _update_comments(client, existing, issue):
     """
     Helper function to sync comments between existing JIRA issue and upstream issue.
@@ -1152,7 +1178,7 @@ def _update_comments(client, existing, issue):
     :returns: Nothing
     """
     # Get all existing comments
-    comments = client.comments(existing)
+    comments = _get_all_comments(client, existing)
     # Remove any comments that have already been added
     comments_d = _comment_matching(issue.comments, comments, issue.url)
     # Loop through the comments that remain

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -511,12 +511,19 @@ def check_comments_for_duplicate(client, result, username):
     :returns: duplicate JIRA issue or None
     :rtype: jira.resource.Issue or None
     """
-    for comment in client.comments(result):
-        search = re.search(r"Marking as duplicate of (\w*)-(\d*)", comment.body)
-        author_label = _jira_user_display_label(comment.author)
-        if search and author_label == username:
-            issue_id = search.groups()[0] + "-" + search.groups()[1]
-            return client.issue(issue_id)
+    page_size = 100
+    start = 0
+    while True:
+        batch = client.comments(result, start_at=start, max_results=page_size)
+        for comment in batch:
+            search = re.search(r"Marking as duplicate of (\w*)-(\d*)", comment.body)
+            author_label = _jira_user_display_label(comment.author)
+            if search and author_label == username:
+                issue_id = search.groups()[0] + "-" + search.groups()[1]
+                return client.issue(issue_id)
+        if len(batch) < page_size:
+            break  # last page; duplicate marker not found
+        start += page_size
     return None
 
 
@@ -1142,52 +1149,40 @@ def _update_title(issue, existing):
     log.info("Updated title")
 
 
-def _get_all_comments(client, issue):
-    """
-    Fetch every comment on a JIRA issue, handling pagination transparently.
-
-    ``client.comments()`` returns at most ``max_results`` entries per call
-    (Jira Cloud defaults to 100).  Iterating in fixed-size pages until a
-    short page is received guarantees we collect all comments regardless of
-    how many there are.
-
-    :param jira.client.JIRA client: JIRA client
-    :param jira.resources.Issue issue: Downstream JIRA issue
-    :returns: All comments on the issue
-    :rtype: list[jira.resources.Comment]
-    """
-    page_size = 100
-    all_comments = []
-    start = 0
-    while True:
-        batch = client.comments(issue, start_at=start, max_results=page_size)
-        all_comments.extend(batch)
-        if len(batch) < page_size:
-            break
-        start += page_size
-    return all_comments
-
-
 def _update_comments(client, existing, issue):
     """
     Helper function to sync comments between existing JIRA issue and upstream issue.
+
+    Jira comments are fetched one page at a time (100 per request).  After
+    each page, upstream comments already present in Jira are removed from the
+    pending set.  Fetching stops as soon as every upstream comment has been
+    matched — so an issue with thousands of Jira comments only requires as
+    many API calls as it takes to find every upstream comment, not a full
+    scan.
 
     :param jira.client.JIRA client: JIRA client
     :param jira.resource.Issue existing: Existing JIRA issue
     :param sync2jira.intermediary.Issue issue: Upstream issue
     :returns: Nothing
     """
-    # Get all existing comments
-    comments = _get_all_comments(client, existing)
-    # Remove any comments that have already been added
-    comments_d = _comment_matching(issue.comments, comments, issue.url)
-    # Loop through the comments that remain
-    for comment in comments_d:
-        # Format and add them
+    page_size = 100
+    start = 0
+    # All upstream comments that still need to be checked / added
+    pending = list(issue.comments)
+
+    while pending:
+        batch = client.comments(existing, start_at=start, max_results=page_size)
+        # Remove upstream comments already present in this page of Jira comments
+        pending = _comment_matching(pending, batch, issue.url)
+        if len(batch) < page_size:
+            break  # last page reached; no more Jira comments to check
+        start += page_size
+
+    for comment in pending:
         comment_body = _truncate_jira_text(_comment_format(comment), issue.url)
         client.add_comment(existing, comment_body)
-    if len(comments_d) > 0:
-        log.info("Comments synchronization done on %i comments.", len(comments_d))
+    if pending:
+        log.info("Comments synchronization done on %i comments.", len(pending))
 
 
 def _update_fixVersion(updates, existing, issue, client):

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -52,7 +52,7 @@ JIRA_TEXT_BODY_MAX_CHARS = 32750
 # If the hyperlink(s) wouldn't leave this much room, drop the hyperlink instead.
 JIRA_TEXT_BODY_MIN_CHARS = 1024
 
-PAGE_SIZE = 100
+JIRA_COMMENTS_PAGE_SIZE = 100
 log = logging.getLogger("sync2jira")
 logging.getLogger("snowflake.connector").setLevel(logging.WARNING)
 
@@ -514,16 +514,18 @@ def check_comments_for_duplicate(client, result, username):
     """
     start = 0
     while True:
-        batch = client.comments(result, start_at=start, max_results=PAGE_SIZE)
+        batch = client.comments(
+            result, start_at=start, max_results=JIRA_COMMENTS_PAGE_SIZE
+        )
         for comment in batch:
             search = re.search(r"Marking as duplicate of (\w*)-(\d*)", comment.body)
             author_label = _jira_user_display_label(comment.author)
             if search and author_label == username:
                 issue_id = search.groups()[0] + "-" + search.groups()[1]
                 return client.issue(issue_id)
-        if len(batch) < PAGE_SIZE:
+        if len(batch) < JIRA_COMMENTS_PAGE_SIZE:
             break  # last page; duplicate marker not found
-        start += PAGE_SIZE
+        start += JIRA_COMMENTS_PAGE_SIZE
     return None
 
 
@@ -1170,12 +1172,14 @@ def _update_comments(client, existing, issue):
     pending = list(issue.comments)
 
     while pending:
-        batch = client.comments(existing, start_at=start, max_results=PAGE_SIZE)
+        batch = client.comments(
+            existing, start_at=start, max_results=JIRA_COMMENTS_PAGE_SIZE
+        )
         # Remove upstream comments already present in this page of Jira comments
         pending = _comment_matching(pending, batch, issue.url)
-        if len(batch) < PAGE_SIZE:
+        if len(batch) < JIRA_COMMENTS_PAGE_SIZE:
             break  # last page reached; no more Jira comments to check
-        start += PAGE_SIZE
+        start += JIRA_COMMENTS_PAGE_SIZE
 
     for comment in pending:
         comment_body = _truncate_jira_text(_comment_format(comment), issue.url)

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -32,6 +32,7 @@ from sync2jira.intermediary import Issue, matcher
 log = logging.getLogger("sync2jira")
 
 UPDATES_KEY = "pr_updates"
+PAGE_SIZE = 100
 
 
 def format_comment(pr, pr_suffix, client):
@@ -92,16 +93,15 @@ def comment_exists(client, existing: JIRAIssue, new_comment):
     :param String new_comment: Formatted comment we're looking for
     :returns: Nothing
     """
-    page_size = 100
     start = 0
     while True:
-        batch = client.comments(existing, start_at=start, max_results=page_size)
+        batch = client.comments(existing, start_at=start, max_results=PAGE_SIZE)
         for comment in batch:
             if new_comment == comment.body:
                 return True
-        if len(batch) < page_size:
+        if len(batch) < PAGE_SIZE:
             break  # last page; comment not found
-        start += page_size
+        start += PAGE_SIZE
     return False
 
 

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -27,12 +27,12 @@ from jira.client import ResultList
 
 # Local Modules
 import sync2jira.downstream_issue as d_issue
+from sync2jira.downstream_issue import JIRA_COMMENTS_PAGE_SIZE
 from sync2jira.intermediary import Issue, matcher
 
 log = logging.getLogger("sync2jira")
 
 UPDATES_KEY = "pr_updates"
-PAGE_SIZE = 100
 
 
 def format_comment(pr, pr_suffix, client):
@@ -95,13 +95,15 @@ def comment_exists(client, existing: JIRAIssue, new_comment):
     """
     start = 0
     while True:
-        batch = client.comments(existing, start_at=start, max_results=PAGE_SIZE)
+        batch = client.comments(
+            existing, start_at=start, max_results=JIRA_COMMENTS_PAGE_SIZE
+        )
         for comment in batch:
             if new_comment == comment.body:
                 return True
-        if len(batch) < PAGE_SIZE:
+        if len(batch) < JIRA_COMMENTS_PAGE_SIZE:
             break  # last page; comment not found
-        start += PAGE_SIZE
+        start += JIRA_COMMENTS_PAGE_SIZE
     return False
 
 

--- a/sync2jira/downstream_pr.py
+++ b/sync2jira/downstream_pr.py
@@ -92,11 +92,16 @@ def comment_exists(client, existing: JIRAIssue, new_comment):
     :param String new_comment: Formatted comment we're looking for
     :returns: Nothing
     """
-    # Grab and loop over comments
-    comments = client.comments(existing)
-    for comment in comments:
-        if new_comment == comment.body:
-            return True
+    page_size = 100
+    start = 0
+    while True:
+        batch = client.comments(existing, start_at=start, max_results=page_size)
+        for comment in batch:
+            if new_comment == comment.body:
+                return True
+        if len(batch) < page_size:
+            break  # last page; comment not found
+        start += page_size
     return False
 
 

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1569,16 +1569,21 @@ class TestDownstreamIssue(unittest.TestCase):
                 else:
                     mock_client.add_comment.assert_not_called()
 
+    @mock.patch(PATH + "_truncate_jira_text")
     @mock.patch(PATH + "_comment_format")
     @mock.patch(PATH + "_comment_matching")
     @mock.patch("jira.client.JIRA")
     def test_update_comments(
-        self, mock_client, mock_comment_matching, mock_comment_format
+        self,
+        mock_client,
+        mock_comment_matching,
+        mock_comment_format,
+        mock_truncate_jira_text,
     ):
         """
-        Single-page case: Jira returns fewer than 100 comments, so the
-        paginator stops after one request.  The one upstream comment that
-        is not yet in Jira is formatted and added.
+        Single-page case: Jira returns fewer than 100 comments so the
+        paginator stops after one request.  The upstream comment that is
+        not yet in Jira is formatted and added to the Jira issue.
         """
         upstream_comment = {"id": "1", "body": "hello", "changed": None}
         self.mock_issue.comments = [upstream_comment]
@@ -1588,6 +1593,7 @@ class TestDownstreamIssue(unittest.TestCase):
             upstream_comment
         ]  # not matched → stays pending
         mock_comment_format.return_value = "formatted_body"
+        mock_truncate_jira_text.return_value = "truncated_body"
 
         d._update_comments(
             client=mock_client, existing=self.mock_downstream, issue=self.mock_issue
@@ -1596,11 +1602,10 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_client.comments.assert_called_once_with(
             self.mock_downstream, start_at=0, max_results=100
         )
-        mock_comment_matching.assert_called_once_with(
-            [upstream_comment], ["jira_comment"], self.mock_issue.url
+        # Verify the right content reached the Jira client
+        mock_client.add_comment.assert_called_once_with(
+            self.mock_downstream, "truncated_body"
         )
-        mock_comment_format.assert_called_once_with(upstream_comment)
-        mock_client.add_comment.assert_called_once_with(self.mock_downstream, mock.ANY)
 
     @mock.patch(PATH + "_comment_format")
     @mock.patch(PATH + "_comment_matching")
@@ -1619,14 +1624,18 @@ class TestDownstreamIssue(unittest.TestCase):
         )
 
         mock_client.comments.assert_not_called()
-        mock_comment_matching.assert_not_called()
         mock_client.add_comment.assert_not_called()
 
+    @mock.patch(PATH + "_truncate_jira_text")
     @mock.patch(PATH + "_comment_format")
     @mock.patch(PATH + "_comment_matching")
     @mock.patch("jira.client.JIRA")
     def test_update_comments_early_stop(
-        self, mock_client, mock_comment_matching, mock_comment_format
+        self,
+        mock_client,
+        mock_comment_matching,
+        mock_comment_format,
+        mock_truncate_jira_text,
     ):
         """
         Early-stop: when all upstream comments are matched on the first
@@ -1637,7 +1646,6 @@ class TestDownstreamIssue(unittest.TestCase):
 
         mock_client.comments.return_value = ["jira_comment"] * 100  # full page
         mock_comment_matching.return_value = []  # all matched on page 1
-
         d._update_comments(
             client=mock_client, existing=self.mock_downstream, issue=self.mock_issue
         )
@@ -1687,6 +1695,98 @@ class TestDownstreamIssue(unittest.TestCase):
         )
         mock_client.comments.assert_any_call(
             self.mock_downstream, start_at=200, max_results=100
+        )
+        mock_client.add_comment.assert_not_called()
+
+    @mock.patch(PATH + "_truncate_jira_text")
+    @mock.patch(PATH + "_comment_format")
+    @mock.patch(PATH + "_comment_matching")
+    @mock.patch("jira.client.JIRA")
+    def test_update_comments_multi_page_not_found(
+        self,
+        mock_client,
+        mock_comment_matching,
+        mock_comment_format,
+        mock_truncate_jira_text,
+    ):
+        """
+        Multi-page case where the upstream comment is never matched and
+        must be added.  Also exercises the zero-items edge case: when
+        Jira returns exactly 100 items the paginator fetches a second
+        page; if that page is empty the loop stops and any remaining
+        pending comments are added.
+        """
+        upstream_comment = {"id": "1", "body": "new comment", "changed": None}
+        self.mock_issue.comments = [upstream_comment]
+
+        mock_client.comments.side_effect = [
+            ["jira_comment"] * 100,  # page 1: full → triggers page 2
+            [],  # page 2: empty → last page
+        ]
+        # Comment not found on either page; pending is never cleared.
+        mock_comment_matching.side_effect = [
+            [upstream_comment],
+            [upstream_comment],
+        ]
+        mock_comment_format.return_value = "formatted_body"
+        mock_truncate_jira_text.return_value = "truncated_body"
+
+        d._update_comments(
+            client=mock_client, existing=self.mock_downstream, issue=self.mock_issue
+        )
+
+        self.assertEqual(mock_client.comments.call_count, 2)
+        mock_client.comments.assert_any_call(
+            self.mock_downstream, start_at=0, max_results=100
+        )
+        mock_client.comments.assert_any_call(
+            self.mock_downstream, start_at=100, max_results=100
+        )
+        # Upstream comment was not in Jira → it should have been added.
+        mock_client.add_comment.assert_called_once_with(
+            self.mock_downstream, "truncated_body"
+        )
+
+    @mock.patch(PATH + "_comment_format")
+    @mock.patch(PATH + "_comment_matching")
+    @mock.patch("jira.client.JIRA")
+    def test_update_comments_found_on_full_intermediate_page(
+        self, mock_client, mock_comment_matching, mock_comment_format
+    ):
+        """
+        Found on a full intermediate page: the upstream comment is not
+        matched on page 1 but is matched on page 2, which is still a
+        full 100-item page.
+
+        After page 2 the pending list is empty, so the loop must exit
+        via the ``while pending:`` guard (not via the short-page break).
+        This proves that finding a comment correctly stops fetching
+        additional pages even when the last-read page was full.
+        """
+        upstream_comment = {"id": "1", "body": "hello", "changed": None}
+        self.mock_issue.comments = [upstream_comment]
+
+        mock_client.comments.side_effect = [
+            ["jira_comment"] * 100,  # page 1: full, not found
+            ["jira_comment"] * 100,  # page 2: full, found → pending clears
+            # page 3 must NOT be fetched
+        ]
+        mock_comment_matching.side_effect = [
+            [upstream_comment],  # page 1: not yet found
+            [],  # page 2: matched, pending cleared
+        ]
+
+        d._update_comments(
+            client=mock_client, existing=self.mock_downstream, issue=self.mock_issue
+        )
+
+        # Exactly two API calls: stop after page 2 despite it being full.
+        self.assertEqual(mock_client.comments.call_count, 2)
+        mock_client.comments.assert_any_call(
+            self.mock_downstream, start_at=0, max_results=100
+        )
+        mock_client.comments.assert_any_call(
+            self.mock_downstream, start_at=100, max_results=100
         )
         mock_client.add_comment.assert_not_called()
 

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1579,7 +1579,8 @@ class TestDownstreamIssue(unittest.TestCase):
         This function tests the 'update_comments' function
         """
         # Set up return values
-        mock_client.comments.return_value = "mock_comments"
+        # Return a list shorter than the page size (100) so the paginator stops
+        mock_client.comments.return_value = ["mock_comment"]
         mock_comment_matching.return_value = ["mock_comments_d"]
         mock_comment_format.return_value = "mock_comment_body"
 
@@ -1589,9 +1590,11 @@ class TestDownstreamIssue(unittest.TestCase):
         )
 
         # Assert all calls were made correctly
-        mock_client.comments.assert_called_with(self.mock_downstream)
+        mock_client.comments.assert_called_with(
+            self.mock_downstream, start_at=0, max_results=100
+        )
         mock_comment_matching.assert_called_with(
-            self.mock_issue.comments, "mock_comments", self.mock_issue.url
+            self.mock_issue.comments, ["mock_comment"], self.mock_issue.url
         )
         mock_comment_format.assert_called_with("mock_comments_d")
         mock_client.add_comment.assert_called_with(

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1576,30 +1576,119 @@ class TestDownstreamIssue(unittest.TestCase):
         self, mock_client, mock_comment_matching, mock_comment_format
     ):
         """
-        This function tests the 'update_comments' function
+        Single-page case: Jira returns fewer than 100 comments, so the
+        paginator stops after one request.  The one upstream comment that
+        is not yet in Jira is formatted and added.
         """
-        # Set up return values
-        # Return a list shorter than the page size (100) so the paginator stops
-        mock_client.comments.return_value = ["mock_comment"]
-        mock_comment_matching.return_value = ["mock_comments_d"]
-        mock_comment_format.return_value = "mock_comment_body"
+        upstream_comment = {"id": "1", "body": "hello", "changed": None}
+        self.mock_issue.comments = [upstream_comment]
 
-        # Call the function
+        mock_client.comments.return_value = ["jira_comment"]  # 1 item < 100 → last page
+        mock_comment_matching.return_value = [
+            upstream_comment
+        ]  # not matched → stays pending
+        mock_comment_format.return_value = "formatted_body"
+
         d._update_comments(
             client=mock_client, existing=self.mock_downstream, issue=self.mock_issue
         )
 
-        # Assert all calls were made correctly
-        mock_client.comments.assert_called_with(
+        mock_client.comments.assert_called_once_with(
             self.mock_downstream, start_at=0, max_results=100
         )
-        mock_comment_matching.assert_called_with(
-            self.mock_issue.comments, ["mock_comment"], self.mock_issue.url
+        mock_comment_matching.assert_called_once_with(
+            [upstream_comment], ["jira_comment"], self.mock_issue.url
         )
-        mock_comment_format.assert_called_with("mock_comments_d")
-        mock_client.add_comment.assert_called_with(
-            self.mock_downstream, "mock_comment_body"
+        mock_comment_format.assert_called_once_with(upstream_comment)
+        mock_client.add_comment.assert_called_once_with(self.mock_downstream, mock.ANY)
+
+    @mock.patch(PATH + "_comment_format")
+    @mock.patch(PATH + "_comment_matching")
+    @mock.patch("jira.client.JIRA")
+    def test_update_comments_no_upstream_comments(
+        self, mock_client, mock_comment_matching, mock_comment_format
+    ):
+        """
+        When there are no upstream comments, the pending list starts empty
+        so the while-loop never enters and Jira is never queried.
+        """
+        self.mock_issue.comments = []
+
+        d._update_comments(
+            client=mock_client, existing=self.mock_downstream, issue=self.mock_issue
         )
+
+        mock_client.comments.assert_not_called()
+        mock_comment_matching.assert_not_called()
+        mock_client.add_comment.assert_not_called()
+
+    @mock.patch(PATH + "_comment_format")
+    @mock.patch(PATH + "_comment_matching")
+    @mock.patch("jira.client.JIRA")
+    def test_update_comments_early_stop(
+        self, mock_client, mock_comment_matching, mock_comment_format
+    ):
+        """
+        Early-stop: when all upstream comments are matched on the first
+        full Jira page (100 items), no further pages are requested.
+        """
+        upstream_comment = {"id": "1", "body": "hello", "changed": None}
+        self.mock_issue.comments = [upstream_comment]
+
+        mock_client.comments.return_value = ["jira_comment"] * 100  # full page
+        mock_comment_matching.return_value = []  # all matched on page 1
+
+        d._update_comments(
+            client=mock_client, existing=self.mock_downstream, issue=self.mock_issue
+        )
+
+        mock_client.comments.assert_called_once_with(
+            self.mock_downstream, start_at=0, max_results=100
+        )
+        mock_client.add_comment.assert_not_called()
+
+    @mock.patch(PATH + "_comment_format")
+    @mock.patch(PATH + "_comment_matching")
+    @mock.patch("jira.client.JIRA")
+    def test_update_comments_multi_page(
+        self, mock_client, mock_comment_matching, mock_comment_format
+    ):
+        """
+        Multi-page case: upstream comment is not found on the first two
+        full pages but is found on the third (short) page.
+        Verifies that start_at advances correctly and add_comment is not
+        called when the comment is eventually matched.
+        """
+        upstream_comment = {"id": "1", "body": "hello", "changed": None}
+        self.mock_issue.comments = [upstream_comment]
+
+        full_page = ["jira_comment"] * 100
+        mock_client.comments.side_effect = [
+            full_page,  # page 1: 100 items → keep going
+            full_page,  # page 2: 100 items → keep going
+            ["jira_comment"],  # page 3: 1 item  → last page
+        ]
+        mock_comment_matching.side_effect = [
+            [upstream_comment],  # page 1: not found, still pending
+            [upstream_comment],  # page 2: not found, still pending
+            [],  # page 3: found, pending cleared
+        ]
+
+        d._update_comments(
+            client=mock_client, existing=self.mock_downstream, issue=self.mock_issue
+        )
+
+        self.assertEqual(mock_client.comments.call_count, 3)
+        mock_client.comments.assert_any_call(
+            self.mock_downstream, start_at=0, max_results=100
+        )
+        mock_client.comments.assert_any_call(
+            self.mock_downstream, start_at=100, max_results=100
+        )
+        mock_client.comments.assert_any_call(
+            self.mock_downstream, start_at=200, max_results=100
+        )
+        mock_client.add_comment.assert_not_called()
 
     def test_update_fixVersion_JIRAError(self):
         """
@@ -2108,24 +2197,79 @@ class TestDownstreamIssue(unittest.TestCase):
     @mock.patch("jira.client.JIRA")
     def test_check_comments_for_duplicates(self, mock_client):
         """
-        Tests 'check_comments_for_duplicates' function
+        Single-page case: duplicate marker is found on the first (short)
+        page; only one Jira API call is made and the duplicate issue is
+        returned immediately.
         """
-        # Set up return values
         mock_comment = MagicMock()
         mock_comment.body = "Marking as duplicate of TEST-1234"
         mock_comment.author.displayName = "mock_user"
-        mock_client.comments.return_value = [mock_comment]
+        mock_client.comments.return_value = [mock_comment]  # 1 item < 100 → last page
         mock_client.issue.return_value = "Successful Call!"
 
-        # Call the function
         response = d.check_comments_for_duplicate(
             client=mock_client, result=self.mock_downstream, username="mock_user"
         )
 
-        # Assert everything was called correctly
         self.assertEqual(response, "Successful Call!")
-        mock_client.comments.assert_called_with(self.mock_downstream)
-        mock_client.issue.assert_called_with("TEST-1234")
+        mock_client.comments.assert_called_once_with(
+            self.mock_downstream, start_at=0, max_results=100
+        )
+        mock_client.issue.assert_called_once_with("TEST-1234")
+
+    @mock.patch("jira.client.JIRA")
+    def test_check_comments_for_duplicates_multi_page(self, mock_client):
+        """
+        Multi-page case: duplicate marker sits on page 2.  Verifies that
+        start_at advances to 100 and that the function returns as soon as
+        the match is found (not after exhausting all pages).
+        """
+        irrelevant = MagicMock()
+        irrelevant.body = "some other comment"
+        irrelevant.author.displayName = "mock_user"
+
+        duplicate_comment = MagicMock()
+        duplicate_comment.body = "Marking as duplicate of TEST-5678"
+        duplicate_comment.author.displayName = "mock_user"
+
+        mock_client.comments.side_effect = [
+            [irrelevant] * 100,  # page 1: full, no match
+            [duplicate_comment],  # page 2: match found → return early
+        ]
+        mock_client.issue.return_value = "duplicate_issue"
+
+        response = d.check_comments_for_duplicate(
+            client=mock_client, result=self.mock_downstream, username="mock_user"
+        )
+
+        self.assertEqual(response, "duplicate_issue")
+        self.assertEqual(mock_client.comments.call_count, 2)
+        mock_client.comments.assert_any_call(
+            self.mock_downstream, start_at=0, max_results=100
+        )
+        mock_client.comments.assert_any_call(
+            self.mock_downstream, start_at=100, max_results=100
+        )
+        mock_client.issue.assert_called_once_with("TEST-5678")
+
+    @mock.patch("jira.client.JIRA")
+    def test_check_comments_for_duplicates_not_found(self, mock_client):
+        """
+        No duplicate marker exists anywhere: all pages are scanned and
+        None is returned.
+        """
+        irrelevant = MagicMock()
+        irrelevant.body = "just a normal comment"
+        irrelevant.author.displayName = "mock_user"
+
+        mock_client.comments.return_value = [irrelevant]  # single page, no match
+
+        response = d.check_comments_for_duplicate(
+            client=mock_client, result=self.mock_downstream, username="mock_user"
+        )
+
+        self.assertIsNone(response)
+        mock_client.issue.assert_not_called()
 
     @mock.patch(PATH + "_comment_format")
     @mock.patch(PATH + "_comment_format_legacy")

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -1607,12 +1607,8 @@ class TestDownstreamIssue(unittest.TestCase):
             self.mock_downstream, "truncated_body"
         )
 
-    @mock.patch(PATH + "_comment_format")
-    @mock.patch(PATH + "_comment_matching")
     @mock.patch("jira.client.JIRA")
-    def test_update_comments_no_upstream_comments(
-        self, mock_client, mock_comment_matching, mock_comment_format
-    ):
+    def test_update_comments_no_upstream_comments(self, mock_client):
         """
         When there are no upstream comments, the pending list starts empty
         so the while-loop never enters and Jira is never queried.
@@ -1626,17 +1622,9 @@ class TestDownstreamIssue(unittest.TestCase):
         mock_client.comments.assert_not_called()
         mock_client.add_comment.assert_not_called()
 
-    @mock.patch(PATH + "_truncate_jira_text")
-    @mock.patch(PATH + "_comment_format")
     @mock.patch(PATH + "_comment_matching")
     @mock.patch("jira.client.JIRA")
-    def test_update_comments_early_stop(
-        self,
-        mock_client,
-        mock_comment_matching,
-        mock_comment_format,
-        mock_truncate_jira_text,
-    ):
+    def test_update_comments_early_stop(self, mock_client, mock_comment_matching):
         """
         Early-stop: when all upstream comments are matched on the first
         full Jira page (100 items), no further pages are requested.
@@ -1655,12 +1643,9 @@ class TestDownstreamIssue(unittest.TestCase):
         )
         mock_client.add_comment.assert_not_called()
 
-    @mock.patch(PATH + "_comment_format")
     @mock.patch(PATH + "_comment_matching")
     @mock.patch("jira.client.JIRA")
-    def test_update_comments_multi_page(
-        self, mock_client, mock_comment_matching, mock_comment_format
-    ):
+    def test_update_comments_multi_page(self, mock_client, mock_comment_matching):
         """
         Multi-page case: upstream comment is not found on the first two
         full pages but is found on the third (short) page.
@@ -1747,11 +1732,10 @@ class TestDownstreamIssue(unittest.TestCase):
             self.mock_downstream, "truncated_body"
         )
 
-    @mock.patch(PATH + "_comment_format")
     @mock.patch(PATH + "_comment_matching")
     @mock.patch("jira.client.JIRA")
     def test_update_comments_found_on_full_intermediate_page(
-        self, mock_client, mock_comment_matching, mock_comment_format
+        self, mock_client, mock_comment_matching
     ):
         """
         Found on a full intermediate page: the upstream comment is not

--- a/tests/test_downstream_pr.py
+++ b/tests/test_downstream_pr.py
@@ -310,9 +310,9 @@ class TestDownstreamPR(unittest.TestCase):
         mock_comment.body = "mock_new_comment"
         other_comment = MagicMock()
         other_comment.body = "something else"
-        self.mock_client.comments.return_value = [mock_comment] + [
-            other_comment
-        ] * 99  # 1 item passes other items
+        self.mock_client.comments.return_value = [other_comment] * 99 + [
+            mock_comment
+        ]  # 1 item passes other items
 
         response = d.comment_exists(
             self.mock_client, "mock_existing", "mock_new_comment"

--- a/tests/test_downstream_pr.py
+++ b/tests/test_downstream_pr.py
@@ -304,22 +304,50 @@ class TestDownstreamPR(unittest.TestCase):
 
     def test_comment_exists_true(self):
         """
-        Single-page case: comment found → returns True immediately.
+        Single-page case: comment found → returns True.
         """
         mock_comment = MagicMock()
         mock_comment.body = "mock_new_comment"
-        self.mock_client.comments.return_value = [
-            mock_comment
-        ]  # 1 item < 100 → last page
+        other_comment = MagicMock()
+        other_comment.body = "something else"
+        self.mock_client.comments.return_value = [mock_comment] + [
+            other_comment
+        ] * 99  # 1 item passes other items
 
         response = d.comment_exists(
             self.mock_client, "mock_existing", "mock_new_comment"
         )
 
+        self.assertTrue(response)
+        # Only one page was fetched despite it being full — early exit worked.
         self.mock_client.comments.assert_called_once_with(
             "mock_existing", start_at=0, max_results=100
         )
-        self.assertTrue(response)
+
+    def test_comment_exists_false_zero_batch(self):
+        """
+        Zero-items edge case: Jira has exactly 100 comments so the
+        paginator fetches a second page which returns empty.  The target
+        comment is not present anywhere so the function returns False.
+        """
+        unrelated = MagicMock()
+        unrelated.body = "some other comment"
+
+        self.mock_client.comments.side_effect = [
+            [unrelated] * 100,  # page 1: full → triggers page 2
+            [],  # page 2: empty → last page
+        ]
+
+        response = d.comment_exists(self.mock_client, "mock_existing", "target comment")
+
+        self.assertFalse(response)
+        self.assertEqual(self.mock_client.comments.call_count, 2)
+        self.mock_client.comments.assert_any_call(
+            "mock_existing", start_at=0, max_results=100
+        )
+        self.mock_client.comments.assert_any_call(
+            "mock_existing", start_at=100, max_results=100
+        )
 
     def test_comment_exists_multi_page(self):
         """

--- a/tests/test_downstream_pr.py
+++ b/tests/test_downstream_pr.py
@@ -285,39 +285,69 @@ class TestDownstreamPR(unittest.TestCase):
 
     def test_comment_exists_false(self):
         """
-        This function tests 'comment_exists' where the comment does not exists
+        Single-page case: comment not found → returns False.
         """
-        # Set up return values
         mock_comment = MagicMock()
         mock_comment.body = "not_mock_new_comment"
-        self.mock_client.comments.return_value = [mock_comment]
+        self.mock_client.comments.return_value = [
+            mock_comment
+        ]  # 1 item < 100 → last page
 
-        # Call the function
         response = d.comment_exists(
             self.mock_client, "mock_existing", "mock_new_comment"
         )
 
-        # Assert Everything was called correctly
-        self.mock_client.comments.assert_called_with("mock_existing")
-        self.assertEqual(response, False)
+        self.mock_client.comments.assert_called_once_with(
+            "mock_existing", start_at=0, max_results=100
+        )
+        self.assertFalse(response)
 
     def test_comment_exists_true(self):
         """
-        This function tests 'comment_exists' where the comment exists
+        Single-page case: comment found → returns True immediately.
         """
-        # Set up return values
         mock_comment = MagicMock()
         mock_comment.body = "mock_new_comment"
-        self.mock_client.comments.return_value = [mock_comment]
+        self.mock_client.comments.return_value = [
+            mock_comment
+        ]  # 1 item < 100 → last page
 
-        # Call the function
         response = d.comment_exists(
             self.mock_client, "mock_existing", "mock_new_comment"
         )
 
-        # Assert Everything was called correctly
-        self.mock_client.comments.assert_called_with("mock_existing")
-        self.assertEqual(response, True)
+        self.mock_client.comments.assert_called_once_with(
+            "mock_existing", start_at=0, max_results=100
+        )
+        self.assertTrue(response)
+
+    def test_comment_exists_multi_page(self):
+        """
+        Multi-page case: comment sits on page 2. Verifies start_at
+        advances and function returns True as soon as the match is found.
+        """
+        unrelated = MagicMock()
+        unrelated.body = "other comment"
+        target = MagicMock()
+        target.body = "mock_new_comment"
+
+        self.mock_client.comments.side_effect = [
+            [unrelated] * 100,  # page 1: full, no match
+            [target],  # page 2: match found → return True
+        ]
+
+        response = d.comment_exists(
+            self.mock_client, "mock_existing", "mock_new_comment"
+        )
+
+        self.assertTrue(response)
+        self.assertEqual(self.mock_client.comments.call_count, 2)
+        self.mock_client.comments.assert_any_call(
+            "mock_existing", start_at=0, max_results=100
+        )
+        self.mock_client.comments.assert_any_call(
+            "mock_existing", start_at=100, max_results=100
+        )
 
     def test_format_comment_closed(self):
         """


### PR DESCRIPTION
The Jira Python library returns only the first 100 comments by default. Therefore, if an issue has more than 100 comments, we need to fetch all comments using pagination before performing any checks.

Reference: https://github.com/pycontribs/jira/issues/1938
