### PR TITLE
Run repository sync in background thread to prevent gateway timeouts and add sync status tracking

### DIFF
--- a/sync-page/event-handler.py
+++ b/sync-page/event-handler.py
@@ -1,9 +1,11 @@
 # Build-In Modules
 import logging
 import os
+import threading
+import uuid
 
 # 3rd Party Modules
-from flask import Flask, redirect, render_template, request
+from flask import Flask, jsonify, redirect, render_template, request
 
 # Local Modules
 from sync2jira.main import initialize_issues, initialize_pr, load_config
@@ -14,6 +16,12 @@ BASE_URL = os.environ["BASE_URL"]
 REDIRECT_URL = os.environ["REDIRECT_URL"]
 config = load_config()
 
+# In-memory job tracker: {job_id: {"status": str, "repos": list, "error": str|None}}
+_jobs: dict = {}
+_jobs_repo = set()
+_jobs_repo_lock = threading.Lock()
+_jobs_lock = threading.Lock()
+
 # Set up our logging
 FORMAT = "[%(asctime)s] %(levelname)s: %(message)s"
 logging.basicConfig(format=FORMAT, level=logging.INFO)
@@ -22,28 +30,76 @@ logging.basicConfig(format=FORMAT, level=logging.WARNING)
 log = logging.getLogger("sync2jira-sync-page")
 
 
+def _run_sync(job_id: str, repos: list):
+    """Run initialize_issues and initialize_pr for each repo in a background thread."""
+    try:
+        for repo_name in repos:
+            log.info(f"[job:{job_id}] Syncing repo: {repo_name}")
+            initialize_issues(config, repo_name=repo_name)
+            initialize_pr(config, repo_name=repo_name)
+            log.info(f"[job:{job_id}] Finished repo: {repo_name}")
+        with _jobs_lock:
+            _jobs[job_id]["status"] = "completed"
+    except Exception as e:
+        log.exception(f"[job:{job_id}] Sync failed")
+        with _jobs_lock:
+            _jobs[job_id]["status"] = "failed"
+            _jobs[job_id]["error"] = str(e)
+    finally:
+        # Release the repo lock only after sync completes (success or failure)
+        with _jobs_repo_lock:
+            _jobs_repo.difference_update(repos)
+
+
 @app.route("/handle-event", methods=["POST"])
 def handle_event():
     """
-    Handler for when a user wants to sync a repo
+    Handler for when a user wants to sync a repo.
+    Kicks off sync in a background thread and immediately returns an
+    in-progress page so the gateway never times out.
     """
     response = request.form
-    synced_repos = []
-    for repo_name, switch in response.items():
-        if switch == "on":
-            # Sync repo_name
-            log.info(f"Starting sync for repo: {repo_name}")
-            initialize_issues(config, repo_name=repo_name)
-            initialize_pr(config, repo_name=repo_name)
-            synced_repos.append(repo_name)
-    if synced_repos:
-        return render_template(
-            "sync-page-success.jinja",
-            synced_repos=synced_repos,
-            url=f"https://{REDIRECT_URL}",
-        )
-    else:
+    repos_to_sync = [repo for repo, switch in response.items() if switch == "on"]
+
+    if not repos_to_sync:
         return render_template("sync-page-failure.jinja", url=f"https://{REDIRECT_URL}")
+
+    with _jobs_repo_lock:
+        already_syncing = set(repos_to_sync) & _jobs_repo
+        if already_syncing:
+            return render_template(
+                "sync-page-failure.jinja",
+                url=f"https://{REDIRECT_URL}",
+                error=f"Already syncing: {', '.join(already_syncing)}",
+            )
+        _jobs_repo.update(repos_to_sync)
+
+    job_id = str(uuid.uuid4())
+    with _jobs_lock:
+        _jobs[job_id] = {"status": "in_progress", "repos": repos_to_sync, "error": None}
+
+    thread = threading.Thread(
+        target=_run_sync, args=(job_id, repos_to_sync), daemon=True
+    )
+    thread.start()
+
+    log.info(f"Started background sync job {job_id} for repos: {repos_to_sync}")
+    return render_template(
+        "sync-page-in-progress.jinja",
+        job_id=job_id,
+        synced_repos=repos_to_sync,
+        url=f"https://{REDIRECT_URL}",
+    )
+
+
+@app.route("/status/<job_id>", methods=["GET"])
+def job_status(job_id: str):
+    """Return JSON status for a background sync job."""
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+    if job is None:
+        return jsonify({"status": "not_found"}), 404
+    return jsonify(job)
 
 
 @app.route("/", methods=["GET"])

--- a/sync-page/event-handler.py
+++ b/sync-page/event-handler.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import threading
+import time
 import uuid
 
 # 3rd Party Modules
@@ -16,11 +17,13 @@ BASE_URL = os.environ["BASE_URL"]
 REDIRECT_URL = os.environ["REDIRECT_URL"]
 config = load_config()
 
-# In-memory job tracker: {job_id: {"status": str, "repos": list, "error": str|None}}
+# In-memory job tracker: {job_id: {"status": str, "repos": list, "error": str|None, "finished_at": float}}
 _jobs: dict = {}
 _jobs_repo = set()
 _jobs_repo_lock = threading.Lock()
 _jobs_lock = threading.Lock()
+
+JOB_TTL_SECONDS = 600  # retain terminal jobs for 10 minutes then discard
 
 # Set up our logging
 FORMAT = "[%(asctime)s] %(levelname)s: %(message)s"
@@ -28,6 +31,28 @@ logging.basicConfig(format=FORMAT, level=logging.INFO)
 logging.basicConfig(format=FORMAT, level=logging.DEBUG)
 logging.basicConfig(format=FORMAT, level=logging.WARNING)
 log = logging.getLogger("sync2jira-sync-page")
+
+
+def _cleanup_expired_jobs():
+    """Daemon thread: remove terminal jobs older than JOB_TTL_SECONDS."""
+    while True:
+        time.sleep(120)  # check every 2 minutes
+        cutoff = time.monotonic() - JOB_TTL_SECONDS
+        with _jobs_lock:
+            if not _jobs:
+                continue
+            expired = [
+                jid
+                for jid, job in _jobs.items()
+                if job["status"] in ("completed", "failed")
+                and job["finished_at"] < cutoff
+            ]
+            for jid in expired:
+                _jobs.pop(jid)
+                log.debug("Expired sync job %s from memory", jid)
+
+
+threading.Thread(target=_cleanup_expired_jobs, daemon=True, name="job-cleanup").start()
 
 
 def _run_sync(job_id: str, repos: list):
@@ -40,11 +65,13 @@ def _run_sync(job_id: str, repos: list):
             log.info(f"[job:{job_id}] Finished repo: {repo_name}")
         with _jobs_lock:
             _jobs[job_id]["status"] = "completed"
+            _jobs[job_id]["finished_at"] = time.monotonic()
     except Exception as e:
         log.exception(f"[job:{job_id}] Sync failed")
         with _jobs_lock:
             _jobs[job_id]["status"] = "failed"
             _jobs[job_id]["error"] = str(e)
+            _jobs[job_id]["finished_at"] = time.monotonic()
     finally:
         # Release the repo lock only after sync completes (success or failure)
         with _jobs_repo_lock:
@@ -76,7 +103,12 @@ def handle_event():
 
     job_id = str(uuid.uuid4())
     with _jobs_lock:
-        _jobs[job_id] = {"status": "in_progress", "repos": repos_to_sync, "error": None}
+        _jobs[job_id] = {
+            "status": "in_progress",
+            "repos": repos_to_sync,
+            "error": None,
+            "finished_at": None,
+        }
 
     thread = threading.Thread(
         target=_run_sync, args=(job_id, repos_to_sync), daemon=True
@@ -95,16 +127,13 @@ def handle_event():
 @app.route("/status/<job_id>", methods=["GET"])
 def job_status(job_id: str):
     """Return JSON status for a background sync job.
-    Cleans up the job from memory once the browser reads a terminal status.
+    Jobs are retained until JOB_TTL_SECONDS after completion, then expired by the cleanup thread.
     """
     with _jobs_lock:
         job = _jobs.get(job_id)
     if job is None:
         return jsonify({"status": "not_found"}), 404
-    if job["status"] in ("completed", "failed"):
-        with _jobs_lock:
-            _jobs.pop(job_id, None)
-    return jsonify(job)
+    return jsonify({k: v for k, v in job.items() if k != "finished_at"})
 
 
 @app.route("/", methods=["GET"])

--- a/sync-page/event-handler.py
+++ b/sync-page/event-handler.py
@@ -94,11 +94,16 @@ def handle_event():
 
 @app.route("/status/<job_id>", methods=["GET"])
 def job_status(job_id: str):
-    """Return JSON status for a background sync job."""
+    """Return JSON status for a background sync job.
+    Cleans up the job from memory once the browser reads a terminal status.
+    """
     with _jobs_lock:
         job = _jobs.get(job_id)
     if job is None:
         return jsonify({"status": "not_found"}), 404
+    if job["status"] in ("completed", "failed"):
+        with _jobs_lock:
+            _jobs.pop(job_id, None)
     return jsonify(job)
 
 

--- a/sync-page/templates/sync-page-failure.jinja
+++ b/sync-page/templates/sync-page-failure.jinja
@@ -46,7 +46,7 @@
       <div class="pf-c-content">
         <h1>Failed to start syncing</h1>
         {% if error %}
-        <p>{{ error }}</p>
+        <p>{{ error | e }}</p>
         {% else %}
         <p>Make sure you selected at least one repo!</p>
         {% endif %}

--- a/sync-page/templates/sync-page-failure.jinja
+++ b/sync-page/templates/sync-page-failure.jinja
@@ -44,8 +44,12 @@
   <main role="main" class="pf-c-page__main" tabindex="-1" id="main-content-page-layout-table-simple">
     <section class="pf-c-page__main-section pf-m-light">
       <div class="pf-c-content">
-        <h1>Failed to started syncing</h1>
+        <h1>Failed to start syncing</h1>
+        {% if error %}
+        <p>{{ error }}</p>
+        {% else %}
         <p>Make sure you selected at least one repo!</p>
+        {% endif %}
       </div>
     </section>
     <section class="pf-c-page__main-section pf-m-no-padding-mobile">

--- a/sync-page/templates/sync-page-in-progress.jinja
+++ b/sync-page/templates/sync-page-in-progress.jinja
@@ -99,6 +99,27 @@
       }
     }
 
+    function buildAlert(modifier, ariaLabel, iconClass, message) {
+      const wrapper = document.createElement("div");
+      wrapper.className = `pf-c-alert ${modifier} pf-m-inline`;
+      wrapper.setAttribute("aria-label", ariaLabel);
+
+      const iconDiv = document.createElement("div");
+      iconDiv.className = "pf-c-alert__icon";
+      const icon = document.createElement("i");
+      icon.className = `fas fa-fw ${iconClass}`;
+      icon.setAttribute("aria-hidden", "true");
+      iconDiv.appendChild(icon);
+
+      const msgP = document.createElement("p");
+      msgP.className = "pf-c-alert__title";
+      msgP.textContent = message;
+
+      wrapper.appendChild(iconDiv);
+      wrapper.appendChild(msgP);
+      return wrapper;
+    }
+
     function poll() {
       fetch("/status/" + jobId)
         .then(r => r.json())
@@ -107,21 +128,17 @@
             clearInterval(pollInterval);
             markAllSpinners("repo-done", "✓");
             document.getElementById("page-title").textContent = "Sync Completed Successfully";
-            document.getElementById("overall-status").innerHTML =
-              '<div class="pf-c-alert pf-m-success pf-m-inline" aria-label="Success alert">' +
-              '<div class="pf-c-alert__icon"><i class="fas fa-fw fa-check-circle" aria-hidden="true"></i></div>' +
-              '<p class="pf-c-alert__title">All selected repos have been synced to JIRA.</p>' +
-              '</div>';
+            document.getElementById("overall-status").replaceChildren(
+              buildAlert("pf-m-success", "Success alert", "fa-check-circle", "All selected repos have been synced to JIRA.")
+            );
             document.getElementById("action-buttons").hidden = false;
           } else if (data.status === "failed") {
             clearInterval(pollInterval);
             markAllSpinners("repo-failed", "✗");
             document.getElementById("page-title").textContent = "Sync Failed";
-            document.getElementById("overall-status").innerHTML =
-              '<div class="pf-c-alert pf-m-danger pf-m-inline" aria-label="Danger alert">' +
-              '<div class="pf-c-alert__icon"><i class="fas fa-fw fa-exclamation-circle" aria-hidden="true"></i></div>' +
-              '<p class="pf-c-alert__title">Sync failed: ' + (data.error || "Unknown error") + '</p>' +
-              '</div>';
+            document.getElementById("overall-status").replaceChildren(
+              buildAlert("pf-m-danger", "Danger alert", "fa-exclamation-circle", "Sync failed: " + (data.error || "Unknown error"))
+            );
             document.getElementById("action-buttons").hidden = false;
           }
           // status === "in_progress": keep polling

--- a/sync-page/templates/sync-page-in-progress.jinja
+++ b/sync-page/templates/sync-page-in-progress.jinja
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en" class="pf-m-redhat-font">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <link rel="icon" type="image/ico" href="{{ url_for('static', filename = 'redhat-favicon.ico') }}"/>
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/@patternfly/patternfly/patternfly.css"
+    crossorigin="anonymous"
+  >
+  <link rel="stylesheet" href="{{ url_for('static', filename = 'font.css') }}" />
+  <title>Sync2Jira - Sync in Progress</title>
+  <style>
+    .sync-status-icon { font-size: 2rem; margin-right: 0.5rem; vertical-align: middle; }
+    .repo-row { display: flex; align-items: center; padding: 0.4rem 0; gap: 0.75rem; }
+    .repo-spinner {
+      display: inline-block;
+      width: 1.1rem; height: 1.1rem;
+      border: 3px solid #ccc;
+      border-top-color: #06c;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      flex-shrink: 0;
+    }
+    .repo-done   { color: #3e8635; font-size: 1.1rem; flex-shrink: 0; }
+    .repo-failed { color: #c9190b; font-size: 1.1rem; flex-shrink: 0; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    #overall-status { margin-top: 1.5rem; }
+  </style>
+</head>
+<body>
+  <div class="pf-c-page" id="page-layout-table-simple">
+  <header role="banner" class="pf-c-page__header">
+    <div class="pf-c-page__header-brand">
+        <h1>Sync2Jira - Sync Page</h1>
+    </div>
+  </header>
+  <div class="pf-c-page__sidebar pf-m-dark">
+    <div class="pf-c-page__sidebar-body">
+      <nav class="pf-c-nav pf-m-dark" aria-label="Global">
+        <ul class="pf-c-nav__list">
+          <li class="pf-c-nav__item pf-m-expandable">
+            <a href="{{ url }}/github" class="pf-c-nav__link" aria-expanded="false">GitHub
+              <span class="pf-c-nav__toggle">
+                <i class="fas fa-angle-right" aria-hidden="true"></i>
+              </span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+  <main role="main" class="pf-c-page__main" tabindex="-1" id="main-content-page-layout-table-simple">
+    <section class="pf-c-page__main-section pf-m-light">
+      <div class="pf-c-content">
+        <h1 id="page-title">Sync in Progress&hellip;</h1>
+        <p>The following repos are being synced. This may take a few minutes for large repos. You can safely leave this page &mdash; the sync will continue in the background.</p>
+      </div>
+    </section>
+
+    <section class="pf-c-page__main-section pf-m-no-padding-mobile">
+      <div class="pf-c-content" style="padding: 1rem 1.5rem;">
+        <ul style="list-style: none; padding: 0;" id="repo-list">
+          {% for repo_name in synced_repos %}
+          <li class="repo-row" id="repo-{{ loop.index }}">
+            <span class="repo-spinner" id="spinner-{{ loop.index }}"></span>
+            <span>{{ repo_name }}</span>
+          </li>
+          {% endfor %}
+        </ul>
+
+        <div id="overall-status"></div>
+
+        <div class="pf-c-form__group pf-m-action" style="margin-top:1.5rem;" id="action-buttons" hidden>
+          <div class="pf-c-form__horizontal-group">
+            <div class="pf-c-form__actions">
+              <a href="{{ url }}/github" class="pf-c-button pf-m-primary">Back to Sync Page</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+  </div>
+
+  <script>
+    const jobId   = "{{ job_id }}";
+    const numRepos = {{ synced_repos | length }};
+    let pollInterval;
+
+    function markAllSpinners(iconClass, iconChar) {
+      for (let i = 1; i <= numRepos; i++) {
+        const spinner = document.getElementById("spinner-" + i);
+        if (spinner && spinner.classList.contains("repo-spinner")) {
+          spinner.outerHTML = `<span class="${iconClass}" id="spinner-${i}">${iconChar}</span>`;
+        }
+      }
+    }
+
+    function poll() {
+      fetch("/status/" + jobId)
+        .then(r => r.json())
+        .then(data => {
+          if (data.status === "completed") {
+            clearInterval(pollInterval);
+            markAllSpinners("repo-done", "✓");
+            document.getElementById("page-title").textContent = "Sync Completed Successfully";
+            document.getElementById("overall-status").innerHTML =
+              '<div class="pf-c-alert pf-m-success pf-m-inline" aria-label="Success alert">' +
+              '<div class="pf-c-alert__icon"><i class="fas fa-fw fa-check-circle" aria-hidden="true"></i></div>' +
+              '<p class="pf-c-alert__title">All selected repos have been synced to JIRA.</p>' +
+              '</div>';
+            document.getElementById("action-buttons").hidden = false;
+          } else if (data.status === "failed") {
+            clearInterval(pollInterval);
+            markAllSpinners("repo-failed", "✗");
+            document.getElementById("page-title").textContent = "Sync Failed";
+            document.getElementById("overall-status").innerHTML =
+              '<div class="pf-c-alert pf-m-danger pf-m-inline" aria-label="Danger alert">' +
+              '<div class="pf-c-alert__icon"><i class="fas fa-fw fa-exclamation-circle" aria-hidden="true"></i></div>' +
+              '<p class="pf-c-alert__title">Sync failed: ' + (data.error || "Unknown error") + '</p>' +
+              '</div>';
+            document.getElementById("action-buttons").hidden = false;
+          }
+          // status === "in_progress": keep polling
+        })
+        .catch(() => { /* network blip — keep polling */ });
+    }
+
+    pollInterval = setInterval(poll, 3000);
+    poll(); // fire immediately on load
+  </script>
+</body>
+</html>

--- a/sync2jira/downstream_issue.py
+++ b/sync2jira/downstream_issue.py
@@ -1485,7 +1485,11 @@ def _update_description(existing, issue, updates_key="issue_updates"):
         # This logging is temporary and will be used to debug an
         # issue regarding phantom updates
         # Get the diff between new_description and existing
-        diff = difflib.unified_diff(existing.fields.description, new_description)
+        old_description = existing.fields.description or ""
+        diff = difflib.unified_diff(
+            old_description.splitlines(keepends=True),
+            new_description.splitlines(keepends=True),
+        )
         log.debug("Issue %s", issue.title)
         log.debug("Diff: %s", "".join(diff))
         log.debug("Old: %s", existing.fields.description)

--- a/tests/test_downstream_issue.py
+++ b/tests/test_downstream_issue.py
@@ -2061,6 +2061,18 @@ class TestDownstreamIssue(unittest.TestCase):
             }
         )
 
+    def test_update_description_none_existing(self):
+        """
+        Tests '_update_description' where existing JIRA description is None (not yet set).
+        This should not raise a TypeError from difflib.
+        """
+        self.mock_downstream.fields.description = None
+
+        # Should not raise — previously crashed with TypeError: NoneType has no len()
+        d._update_description(existing=self.mock_downstream, issue=self.mock_issue)
+
+        self.mock_downstream.update.assert_called_once()
+
     def test_update_description_add_field(self):
         """
         This function tests '_update_description' where we just have to add a description field


### PR DESCRIPTION
**Problem**

Currently, repository synchronization is performed synchronously in the main request-handling flow. Since syncing repositories can take a significant amount of time, the request does not return a response before the gateway timeout occurs.

This results in a gateway timeout even though the synchronization may still be processing.

**Changes**
Background repository synchronization

- Moved the repository synchronization work to a background thread.
- The main request-handling thread is freed immediately after starting the background job, allowing a valid response to be returned before the gateway timeout.
- This does not introduce parallel/multi-threaded repository synchronization within a single job. The background thread processes the selected repositories as part of the same sync job.

Repository-level locking

- Added repository-level locking to prevent the same repository from being synchronized by multiple user requests at the same time.
- Different repositories are still allowed to be synchronized independently.
- Once a repository sync completes or fails, the repository is removed from the active sync lock so it can be synchronized again.

Job tracking and status

- Added a job ID for each sync request.
- Added an in-memory job dictionary to maintain the status of each individual request.
- Each job tracks its current status and any error that occurs during synchronization.
- The job status is exposed through a status endpoint so the frontend can retrieve the status for the specific user's request.
- Once the sync job completes, the job information is cleaned up from the job dictionary as appropriate.

**Sync status UI**

After submitting a sync request:

- The user is redirected to an in-progress status page.
- The page polls the job status endpoint every 3 seconds.
- Repository sync status is updated based on the latest job information.
- On successful completion, the user is shown a success page.
- If the synchronization fails, the user is shown a failure page with the corresponding error message.

 **downstream.py description handling**

While updating the downstream issue description, existing.fields.description can be None.

Previously, passing a None value to difflib.unified_diff() caused the description comparison to fail.

Updated the description handling to:

- Treat a None existing description as an empty string.
- Use splitlines(keepends=True) when generating the unified diff so that line-level changes and line endings are handled correctly.

**Tests**

- Added a test case covering the downstream issue description update when the existing description is None.
- The test verifies that the description diff/update functionality works correctly with an empty existing description.

**Result**

With these changes, long-running repository synchronization no longer blocks the HTTP request until completion, preventing gateway timeout errors while providing users with real-time progress/status feedback for their sync request.